### PR TITLE
Refactor built in widget and remove opacity force change

### DIFF
--- a/lib/src/widget/built_in/built_in.dart
+++ b/lib/src/widget/built_in/built_in.dart
@@ -63,29 +63,20 @@ class BuiltInContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Widget content = Text(
-      title,
-      style: style.titleTextStyle(context)?.copyWith(
-            color: foregroundColor,
-          ),
-    );
-
     final showColumn =
         description?.isNotEmpty == true || showProgressBar == true;
 
     if (showColumn) {
-      content = Column(
+      return Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          content,
+          buildTitle(context),
           if (description?.isNotEmpty == true) ...[
             const SizedBox(height: 4),
             Text(
               description!,
-              style: style.descriptionTextStyle(context)?.copyWith(
-                    color: foregroundColor?.withOpacity(.7),
-                  ),
+              style: style.descriptionTextStyle(context),
             ),
           ],
           if (showProgressBar) ...[
@@ -101,6 +92,15 @@ class BuiltInContent extends StatelessWidget {
       );
     }
 
-    return content;
+    return buildTitle(context);
+  }
+
+  Text buildTitle(BuildContext context) {
+    return Text(
+      title,
+      style: style.titleTextStyle(context)?.copyWith(
+            color: foregroundColor,
+          ),
+    );
   }
 }


### PR DESCRIPTION
Make `content ` more readable.

Line 87 forces us to have 0.7 opacity which we may not want to have in builtIn widgets.