### PR TITLE
Feature: dismiss direction

### DIFF
--- a/lib/src/core/toastification.dart
+++ b/lib/src/core/toastification.dart
@@ -117,6 +117,7 @@ class Toastification {
     Duration? animationDuration,
     Duration? autoCloseDuration,
     OverlayState? overlayState,
+    DismissDirection? dismissDirection,
     ToastificationCallbacks callbacks = const ToastificationCallbacks(),
   }) {
     direction ??= Directionality.of(context);
@@ -235,6 +236,7 @@ class Toastification {
     CloseButtonShowType? closeButtonShowType,
     bool? closeOnClick,
     bool? dragToClose,
+    DismissDirection? dismissDirection,
     bool? pauseOnHover,
     ToastificationCallbacks callbacks = const ToastificationCallbacks(),
   }) {
@@ -268,6 +270,7 @@ class Toastification {
           closeButtonShowType: closeButtonShowType,
           closeOnClick: closeOnClick,
           dragToClose: dragToClose,
+          dismissDirection: dismissDirection,
           pauseOnHover: pauseOnHover,
           callbacks: callbacks,
         );

--- a/lib/src/widget/built_in/built_in_builder.dart
+++ b/lib/src/widget/built_in/built_in_builder.dart
@@ -29,6 +29,7 @@ class BuiltInBuilder extends StatelessWidget {
     this.closeButtonShowType,
     this.closeOnClick,
     this.dragToClose,
+    this.dismissDirection,
     this.pauseOnHover,
     this.callbacks = const ToastificationCallbacks(),
   });
@@ -68,6 +69,8 @@ class BuiltInBuilder extends StatelessWidget {
   final bool? closeOnClick;
 
   final bool? dragToClose;
+
+  final DismissDirection? dismissDirection;
 
   final bool? pauseOnHover;
 
@@ -334,6 +337,7 @@ class BuiltInContainer extends StatelessWidget {
     required this.closeOnClick,
     required this.pauseOnHover,
     required this.dragToClose,
+    this.dismissDirection,
     required this.callbacks,
     required this.child,
   });
@@ -347,6 +351,8 @@ class BuiltInContainer extends StatelessWidget {
   final bool closeOnClick;
 
   final bool dragToClose;
+
+  final DismissDirection? dismissDirection;
 
   final bool pauseOnHover;
 
@@ -390,6 +396,7 @@ class BuiltInContainer extends StatelessWidget {
       toast = _FadeDismissible(
         item: item,
         pauseOnHover: pauseOnHover,
+        dismissDirection: dismissDirection,
         onDismissed: callbacks.onDismissed == null
             ? null
             : () {
@@ -408,12 +415,14 @@ class _FadeDismissible extends StatefulWidget {
     required this.item,
     required this.pauseOnHover,
     this.onDismissed,
+    this.dismissDirection,
     required this.child,
   });
 
   final ToastificationItem item;
   final bool pauseOnHover;
   final VoidCallback? onDismissed;
+  final DismissDirection? dismissDirection;
   final Widget child;
 
   @override
@@ -439,6 +448,7 @@ class _FadeDismissibleState extends State<_FadeDismissible> {
             currentOpacity = details.progress;
           });
         },
+        direction: widget.dismissDirection ?? DismissDirection.horizontal,
         behavior: HitTestBehavior.deferToChild,
         onDismissed: (direction) {
           // call the onDismissed callback

--- a/lib/src/widget/built_in/built_in_builder.dart
+++ b/lib/src/widget/built_in/built_in_builder.dart
@@ -90,6 +90,7 @@ class BuiltInBuilder extends StatelessWidget {
       showProgressBar: showProgressBar,
       closeOnClick: closeOnClick,
       dragToClose: dragToClose,
+      dismissDirection: dismissDirection,
       pauseOnHover: pauseOnHover,
       callbacks: callbacks,
       child: BuiltInToastBuilder(


### PR DESCRIPTION
## Overview

It would be convenient to specify a dismiss direction for the toast container if desired. This PR will allow users to specify which direction they would like to dismiss their toast containers if they enable `dragToClose`.

## Changed
- src/core/toastification.dart: the `show` method now accepts an argument of type `DismissDirection?` so that users can optionally specify which direction to dismiss their toast. That argument is bubbled down to the `BuiltInBuilder`
- src/widget/built_in/built_in_builder.dart: in the builder method of `BuiltInBuilder` the `BuiltInContainer` widget accepts the `dismissDirection` argument and passes that down to the `_FadeDismissible` widget if the `dragToClose` argument is set to `true`. In `_FadeDismissible`, the dismiss direction defaults to `DismissDirection.horizontal`, which is the standard default for the Dismissible widget.