### PR TITLE
Fix offset in description when title is null

### DIFF
--- a/lib/src/widget/built_in/built_in.dart
+++ b/lib/src/widget/built_in/built_in.dart
@@ -110,7 +110,7 @@ class BuiltInContent extends StatelessWidget {
           ),
         ],
         if (showProgressBar) ...[
-          const SizedBox(height: 10),
+          if (title != null || description != null) const SizedBox(height: 10),
           ProgressIndicatorTheme(
             data:
                 progressIndicatorTheme ?? style.progressIndicatorTheme(context),

--- a/lib/src/widget/built_in/built_in.dart
+++ b/lib/src/widget/built_in/built_in.dart
@@ -101,7 +101,7 @@ class BuiltInContent extends StatelessWidget {
       children: [
         content,
         if (description != null) ...[
-          const SizedBox(height: 6),
+          if (title != null) const SizedBox(height: 6),
           DefaultTextStyle.merge(
             style: style.descriptionTextStyle(context)?.copyWith(
                   color: foregroundColor,


### PR DESCRIPTION
# Problem
When title is null, description is offset by `SizedBox` above. It is supposed to be a spacing after title, but not needed when title is null.
<img width="399" alt="Screenshot 2024-08-08 at 11 59 48" src="https://github.com/user-attachments/assets/0b0758d4-b7b5-441d-a67e-fb02e51cdcdc">

# Change
This MR fixes it by enabling `SizedBox` only if both title and description are set.
<img width="406" alt="Screenshot 2024-08-08 at 11 59 54" src="https://github.com/user-attachments/assets/4a479b72-5080-46fb-8566-8aaff4c1e52a">

