### PR TITLE
fix: Cannot hide the icon if the style is FlatColored

### DIFF
--- a/lib/src/widget/built_in/built_in_builder.dart
+++ b/lib/src/widget/built_in/built_in_builder.dart
@@ -273,6 +273,7 @@ class BuiltInToastBuilder extends StatelessWidget {
               backgroundColor: backgroundColor,
               foregroundColor: foregroundColor,
               icon: icon,
+              showIcon: showIcon,
               brightness: brightness,
               padding: padding,
               borderRadius: borderRadius,


### PR DESCRIPTION
Pass the missing parameter `showIcon` for FlatColoredToastWidget