### PR TITLE
Add extra bottom margin to account for keyboard

### DIFF
--- a/example/lib/src/features/home/views/pages/home.dart
+++ b/example/lib/src/features/home/views/pages/home.dart
@@ -35,7 +35,7 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return ToastificationConfigProvider(
       config: ToastificationConfig(
-        marginBuilder: (alignment) => const EdgeInsets.fromLTRB(0, 16, 0, 110),
+        marginBuilder: (context, alignment) => const EdgeInsets.fromLTRB(0, 16, 0, 110),
       ),
       child: const Scrollbar(
         child: Scaffold(

--- a/lib/src/core/toastification_config.dart
+++ b/lib/src/core/toastification_config.dart
@@ -84,14 +84,13 @@ Widget _defaultAnimationBuilderConfig(
 /// Default margin builder for [Toastification]
 EdgeInsetsGeometry _defaultMarginBuilder(BuildContext context, AlignmentGeometry alignment) {
   final y = alignment.resolve(Directionality.of(context)).y;
-  final kbdBottomMargin = MediaQuery.of(context).viewInsets.bottom;
 
   log('Margin builder called with y: $y');
   log('Margin builder called with alignment: $alignment');
 
   return switch (y) {
-    <= -0.5 => const EdgeInsets.only(top: 12),
-    >= 0.5 => EdgeInsets.only(bottom: 12 + kbdBottomMargin),
-    _ => EdgeInsets.zero,
+    <= -0.5 => const EdgeInsets.only(top: 12) + MediaQuery.of(context).viewInsets,
+    >= 0.5 => const EdgeInsets.only(bottom: 12) + MediaQuery.of(context).viewInsets,
+    _ => MediaQuery.of(context).viewInsets,
   };
 }

--- a/lib/src/core/toastification_config.dart
+++ b/lib/src/core/toastification_config.dart
@@ -83,11 +83,7 @@ Widget _defaultAnimationBuilderConfig(
 
 /// Default margin builder for [Toastification]
 EdgeInsetsGeometry _defaultMarginBuilder(BuildContext context, AlignmentGeometry alignment) {
-  final y = alignment is Alignment
-      ? alignment.y
-      : alignment is AlignmentDirectional
-          ? alignment.y
-          : 0.0;
+  final y = alignment.resolve(Directionality.of(context)).y;
   final kbdBottomMargin = MediaQuery.of(context).viewInsets.bottom;
 
   log('Margin builder called with y: $y');

--- a/lib/src/core/toastification_config.dart
+++ b/lib/src/core/toastification_config.dart
@@ -9,6 +9,7 @@ const _itemAnimationDuration = Duration(milliseconds: 600);
 const _defaultWidth = 400.0;
 const _defaultClipBehavior = Clip.none;
 
+
 /// you can use [ToastificationConfig] class to change default values of [Toastification]
 ///
 /// when you are using [show] or [showCustom] methods,
@@ -36,7 +37,7 @@ class ToastificationConfig extends Equatable {
   final Clip clipBehavior;
   final Duration animationDuration;
   final ToastificationAnimationBuilder animationBuilder;
-  final EdgeInsetsGeometry Function(AlignmentGeometry alignment) marginBuilder;
+  final EdgeInsetsGeometry Function(BuildContext context, AlignmentGeometry alignment) marginBuilder;
 
   // Copy with method for ToastificationConfig
   ToastificationConfig copyWith({
@@ -45,7 +46,7 @@ class ToastificationConfig extends Equatable {
     Clip? clipBehavior,
     Duration? animationDuration,
     ToastificationAnimationBuilder? animationBuilder,
-    EdgeInsetsGeometry Function(AlignmentGeometry alignment)? marginBuilder,
+    EdgeInsetsGeometry Function(BuildContext context, AlignmentGeometry alignment)? marginBuilder,
   }) {
     return ToastificationConfig(
       alignment: alignment ?? this.alignment,
@@ -81,22 +82,20 @@ Widget _defaultAnimationBuilderConfig(
 }
 
 /// Default margin builder for [Toastification]
-EdgeInsetsGeometry _defaultMarginBuilder(AlignmentGeometry alignment) {
+EdgeInsetsGeometry _defaultMarginBuilder(BuildContext context, AlignmentGeometry alignment) {
   final y = alignment is Alignment
       ? alignment.y
       : alignment is AlignmentDirectional
           ? alignment.y
           : 0.0;
-  Alignment.topCenter;
+  final kbdBottomMargin = MediaQuery.of(context).viewInsets.bottom;
 
   log('Margin builder called with y: $y');
   log('Margin builder called with alignment: $alignment');
 
   return switch (y) {
-    >= -1 => const EdgeInsets.only(top: 12),
-    >= -0.5 => const EdgeInsets.only(top: 12),
-    <= 0.5 => const EdgeInsets.only(bottom: 12),
-    <= 1 => const EdgeInsets.only(bottom: 12),
+    <= -0.5 => const EdgeInsets.only(top: 12),
+    >= 0.5 => EdgeInsets.only(bottom: 12 + kbdBottomMargin),
     _ => EdgeInsets.zero,
   };
 }

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -200,7 +200,7 @@ class ToastificationManager {
         Widget overlay = Align(
           alignment: alignment,
           child: Container(
-            margin: config.marginBuilder(alignment),
+            margin: config.marginBuilder(context, alignment),
             constraints: BoxConstraints.tightFor(
               width: config.itemWidth,
             ),


### PR DESCRIPTION
Closes #124

When notification alignment is the bottom part of the screen, add extra margin to account for active keyboard, so the notifications appear above it and not behind.

Breaking changes:
- Add `BuildContext context` to `ToastificationConfig.marginBuilder` signature.

<img src="https://github.com/user-attachments/assets/8fb62817-ba72-4da7-afe4-0dd6160da7ed" data-canonical-src="https://github.com/user-attachments/assets/8fb62817-ba72-4da7-afe4-0dd6160da7ed" width="300" />
