### PR TITLE
Fix: AnimationController.dispose() called more than once. on multiple action show

### DIFF
--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -27,6 +27,8 @@ class ToastificationManager {
   /// if the list is empty, the overlay entry will be removed
   final List<ToastificationItem> _notifications = [];
 
+  Duration delay = const Duration(milliseconds: 10);
+
   /// Shows a [ToastificationItem] with the given [builder] and [animationBuilder].
   ///
   /// if the [_notifications] list is empty, we will create the [_overlayEntry]
@@ -53,7 +55,6 @@ class ToastificationManager {
 
     /// we need this delay because we want to show the item animation after
     /// the overlay created
-    var delay = const Duration(milliseconds: 10);
 
     if (_overlayEntry == null) {
       _createNotificationHolder(overlayState);
@@ -103,7 +104,7 @@ class ToastificationManager {
     bool showRemoveAnimation = true,
   }) {
     final index = _notifications.indexOf(notification);
-
+    // print("Toastification Manager Dismiss Notifications: $_notifications");
     if (index != -1) {
       notification = _notifications[index];
 
@@ -143,7 +144,7 @@ class ToastificationManager {
       // TODO(payam): add the condition before the delay
       /// we will remove the [_overlayEntry] if there are no notifications
       Future.delayed(
-        removedItem.animationDuration ?? config.animationDuration,
+        (removedItem.animationDuration ?? config.animationDuration) + delay,
         () {
           if (_notifications.isEmpty) {
             _overlayEntry?.remove();


### PR DESCRIPTION
**Problem:** `AnimationController.dispose()` was called multiple times, leading to errors.

**Scenarios:**
1. Disposing multiple toasts concurrently.
2. Disposing a single toast with a progress bar.

**Root Cause:**
In the file `toastification_manager.dart`, there was a delay between creating and inserting the `OverlayEntry` and adding the toast to the `_notifications` list.

`
if (_overlayEntry == null) {
    _createNotificationHolder(overlayState);

    // TODO: remove this delay in future updates
    delay = const Duration(milliseconds: 300);
}

Future.delayed(
  delay,
  () {
    _notifications.insert(0, item);

    _listGlobalKey.currentState?.insertItem(
      0,
      duration: _createAnimationDuration(item),
    );
  },
);
`

This delay caused a timing issue, where the toast was being created but not yet added to **_notifications**, while the **OverlayEntry** was removed prematurely in the following code:

`
Future.delayed(
  (removedItem.animationDuration ?? config.animationDuration),
  () {
    if (_notifications.isEmpty) {
      _overlayEntry?.remove();
      _overlayEntry = null;
    }
  },
);
`

Because the toast wasn’t in the list yet, the **OverlayEntry** was removed too early, leading to multiple calls of **AnimationController.dispose()**.

**Solution:**
The solution was to account for the initial delay in the toast creation process when scheduling the removal of the `OverlayEntry`. This ensures that the overlay is only removed after the toast has been properly inserted and displayed:

`
Future.delayed(
  delay + (removedItem.animationDuration ?? config.animationDuration),
  () {
    if (_notifications.isEmpty) {
      _overlayEntry?.remove();
      _overlayEntry = null;
    }
  },
);
`

This synchronization prevents the **AnimationController.dispose()** from being called multiple times.

closes #132 #54 