### PR TITLE
Update CONTRIBUTING.md link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Toastification was redesigned by [Sepide Moqadasi](https://sepide.design/). We w
 
 Contributions are always welcome! If you have any suggestions, bug reports, or feature requests, please open an issue on the GitHub repository.
 
-If you would like to contribute to the project, please read the [CONTRIBUTING.md](https://github.com/payam-zahedi/toastification/CONTRIBUTING.md "CONTRIBUTING.md") file for more information on how to contribute.
+If you would like to contribute to the project, please read the [CONTRIBUTING.md](https://github.com/payam-zahedi/toastification/blob/main/CONTRIBUTING.md "CONTRIBUTING.md") file for more information on how to contribute.
 
 ## License
 


### PR DESCRIPTION
- Updated the broken link to the Contributing.md file in the documentation.
- The old link pointed to https://github.com/payam-zahedi/toastification/CONTRIBUTING.md, which was incorrect.
- Replaced it with the correct link: https://github.com/payam-zahedi/toastification/blob/main/CONTRIBUTING.md.

close #155 