### PR TITLE
Add `maxToastLimit` to ToastificationConfig and Improve Toast Management

### DIFF
--- a/lib/src/core/toastification_config.dart
+++ b/lib/src/core/toastification_config.dart
@@ -31,6 +31,7 @@ class ToastificationConfig extends Equatable {
     this.animationBuilder = _defaultAnimationBuilderConfig,
     this.marginBuilder = _defaultMarginBuilder,
     this.applyMediaQueryViewInsets = true,
+    this.maxToastLimit = 10,
   });
 
   final AlignmentGeometry alignment;
@@ -46,6 +47,11 @@ class ToastificationConfig extends Equatable {
 
   /// Builder method for creating margin for Toastification Overlay.
   final ToastificationMarginBuilder marginBuilder;
+
+  /// The maximum number of toasts that can be displayed at the same time.
+  /// If the number of toasts exceeds this limit, the oldest toast will be removed.
+  /// The default value is 10.
+  final int maxToastLimit;
 
   /// Whether to apply the viewInsets to the margin of the Toastification Overlay.
   /// Basically, this is used to move the Toastification Overlay up or down when the keyboard is shown.

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -65,13 +65,10 @@ class ToastificationManager {
       },
     );
 
-    /// we need this delay because we want to show the item animation after
-    /// the overlay created
     Duration delay = const Duration(milliseconds: 10);
 
     if (_overlayEntry == null) {
       _createNotificationHolder(overlayState);
-
       delay = _createOverlayDelay;
     }
 
@@ -84,10 +81,12 @@ class ToastificationManager {
           0,
           duration: _createAnimationDuration(item),
         );
+
+        while (_notifications.length > config.maxToastLimit) {
+          dismissLast();
+        }
       },
     );
-
-    // TODO(payam): add limit count feature
 
     return item;
   }
@@ -116,7 +115,6 @@ class ToastificationManager {
     bool showRemoveAnimation = true,
   }) {
     final index = _notifications.indexOf(notification);
-    // print("Toastification Manager Dismiss Notifications: $_notifications");
     if (index != -1) {
       notification = _notifications[index];
 
@@ -126,8 +124,6 @@ class ToastificationManager {
 
       final removedItem = _notifications.removeAt(index);
 
-      /// if the [showRemoveAnimation] is true, we will show the remove animation
-      /// of the notification.
       if (showRemoveAnimation) {
         _listGlobalKey.currentState?.removeItem(
           index,
@@ -141,9 +137,6 @@ class ToastificationManager {
           },
           duration: _createAnimationDuration(removedItem),
         );
-
-        /// if the [showRemoveAnimation] is false, we will remove the notification
-        /// without showing the remove animation.
       } else {
         _listGlobalKey.currentState?.removeItem(
           index,
@@ -153,9 +146,6 @@ class ToastificationManager {
         );
       }
 
-      /// we will remove the [_overlayEntry] if there are no notifications
-      /// We need to check if the _notifications list is empty twice.
-      /// To make sure after the delay, there are no new notifications added.
       if (_notifications.isEmpty) {
         Future.delayed(
           (removedItem.animationDuration ?? config.animationDuration) +

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -115,6 +115,7 @@ class ToastificationManager {
     bool showRemoveAnimation = true,
   }) {
     final index = _notifications.indexOf(notification);
+    // print("Toastification Manager Dismiss Notifications: $_notifications");
     if (index != -1) {
       notification = _notifications[index];
 
@@ -124,6 +125,8 @@ class ToastificationManager {
 
       final removedItem = _notifications.removeAt(index);
 
+      /// if the [showRemoveAnimation] is true, we will show the remove animation
+      /// of the notification.
       if (showRemoveAnimation) {
         _listGlobalKey.currentState?.removeItem(
           index,
@@ -137,6 +140,9 @@ class ToastificationManager {
           },
           duration: _createAnimationDuration(removedItem),
         );
+
+        /// if the [showRemoveAnimation] is false, we will remove the notification
+        /// without showing the remove animation.
       } else {
         _listGlobalKey.currentState?.removeItem(
           index,
@@ -146,6 +152,9 @@ class ToastificationManager {
         );
       }
 
+      /// we will remove the [_overlayEntry] if there are no notifications
+      /// We need to check if the _notifications list is empty twice.
+      /// To make sure after the delay, there are no new notifications added.
       if (_notifications.isEmpty) {
         Future.delayed(
           (removedItem.animationDuration ?? config.animationDuration) +


### PR DESCRIPTION
This pull request introduces the `maxToastLimit` property to the `ToastificationConfig` class, allowing developers to define the maximum number of toasts displayed simultaneously. Additionally, it improves toast management by ensuring older toasts are dismissed automatically when the limit is exceeded. Key changes include:

- **Added `maxToastLimit` to ToastificationConfig:**
  - Defines the maximum number of toasts displayed at once.
  - Defaults to `10`, but can be customized via the configuration.

- **Optimized Toast Display Logic:**
  - Automatically dismisses the oldest toast when the number of active toasts exceeds `maxToastLimit`.

close #113 