### PR TITLE
Prevent delayed toasts from showing after dismiss/dismissAll is called

### DIFF
--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -27,6 +27,9 @@ class ToastificationManager {
   /// if the list is empty, the overlay entry will be removed
   final List<ToastificationItem> _notifications = [];
 
+   /// This list keeps track of toast items that are scheduled to be added.
+  final List<ToastificationItem> _pendingNotifications = [];
+
   /// this is the delay for showing the overlay entry
   /// We need this delay because we want to show the item animation after
   /// the overlay created
@@ -75,9 +78,17 @@ class ToastificationManager {
       delay = _createOverlayDelay;
     }
 
+    _pendingNotifications.add(item);
+
     Future.delayed(
       delay,
       () {
+        if (!_pendingNotifications.contains(item)) {
+          return;
+        }
+
+        _pendingNotifications.remove(item);
+
         _notifications.insert(0, item);
 
         _listGlobalKey.currentState?.insertItem(
@@ -115,6 +126,9 @@ class ToastificationManager {
     ToastificationItem notification, {
     bool showRemoveAnimation = true,
   }) {
+    // Remove from pending notifications if it's there
+    _pendingNotifications.remove(notification);
+
     final index = _notifications.indexOf(notification);
     // print("Toastification Manager Dismiss Notifications: $_notifications");
     if (index != -1) {
@@ -175,6 +189,9 @@ class ToastificationManager {
   /// The [delayForAnimation] parameter is optional and defaults to true.
   /// When it is true, it adds a delay for better animation.
   void dismissAll({bool delayForAnimation = true}) async {
+
+    _pendingNotifications.clear();
+
     // Creates a new list cloneList that has all the notifications from the _notifications list, but in reverse order.
     final cloneList = _notifications.toList(growable: false).reversed;
 

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:collection/collection.dart';
 import 'package:toastification/src/widget/toast_builder.dart';
 import 'package:toastification/toastification.dart';
 

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -3,11 +3,18 @@ import 'package:collection/collection.dart';
 import 'package:toastification/src/widget/toast_builder.dart';
 import 'package:toastification/toastification.dart';
 
-/// This class is responsible for managing the [Toastification] items
-/// we have several ToastificationManagers for each [Alignment] object
+class _NotificationEntry {
+  final ToastificationItem item;
+  bool isInserted;
+
+  _NotificationEntry({required this.item, this.isInserted = false});
+}
+
+/// This class is responsible for managing the [Toastification] items.
+/// We have several ToastificationManagers for each [Alignment] object.
 ///
-/// You don't need to use [ToastificationManager] directly
-/// [Toastification] will handle them internally
+/// You don't need to use [ToastificationManager] directly.
+/// [Toastification] will handle them internally.
 class ToastificationManager {
   ToastificationManager({
     required this.alignment,
@@ -20,34 +27,26 @@ class ToastificationManager {
 
   OverlayEntry? _overlayEntry;
 
-  /// this key is attached to [AnimatedList] so we can add or remove items using it.
+  /// This key is attached to [AnimatedList] so we can add or remove items using it.
   final _listGlobalKey = GlobalKey<AnimatedListState>();
 
-  /// this is the list of items that are currently shown
-  /// if the list is empty, the overlay entry will be removed
-  final List<ToastificationItem> _notifications = [];
+  /// This map holds all the notifications, both pending and shown.
+  /// The key is the unique ID of each notification.
+  final Map<String, _NotificationEntry> _notificationsMap = {};
 
-   /// This list keeps track of toast items that are scheduled to be added.
-  final List<ToastificationItem> _pendingNotifications = [];
-
-  /// this is the delay for showing the overlay entry
-  /// We need this delay because we want to show the item animation after
-  /// the overlay created
+  /// This is the delay for removing the overlay entry.
   ///
-  /// When we want to show first toast, we need to wait for the overlay to be created
-  /// and then show the toast item.
-  final _createOverlayDelay = const Duration(milliseconds: 100);
-
-  /// this is the delay for removing the overlay entry
-  ///
-  /// when we want to remove the last toast, we need to wait for the animation
+  /// When we want to remove the last toast, we need to wait for the animation
   /// to be completed and then remove the overlay.
   final _removeOverlayDelay = const Duration(milliseconds: 50);
 
+  /// A flag to indicate if `dismissAll` has been called.
+  bool _dismissAllCalled = false;
+
   /// Shows a [ToastificationItem] with the given [builder] and [animationBuilder].
   ///
-  /// if the [_notifications] list is empty, we will create the [_overlayEntry]
-  /// otherwise we will just add the [item] to the [_notifications] list.
+  /// If the overlay is not yet created, we will create the [_overlayEntry],
+  /// and schedule the insertion of the item after the overlay is ready.
   ToastificationItem showCustom({
     required OverlayState overlayState,
     required ToastificationBuilder builder,
@@ -68,157 +67,191 @@ class ToastificationManager {
       },
     );
 
-    /// we need this delay because we want to show the item animation after
-    /// the overlay created
-    Duration delay = const Duration(milliseconds: 10);
+    final entry = _NotificationEntry(item: item);
 
-    if (_overlayEntry == null) {
-      _createNotificationHolder(overlayState);
+    // Add the item to the notifications map immediately with pending status.
+    _notificationsMap[item.id] = entry;
 
-      delay = _createOverlayDelay;
+    if (_dismissAllCalled) {
+      // If dismissAll has been called, do not proceed to show the toast.
+      _notificationsMap.remove(item.id);
+      return item;
     }
 
-    _pendingNotifications.add(item);
+    if (_overlayEntry == null) {
+      // Overlay is not yet created; create it.
+      _createNotificationHolder(overlayState);
 
-    Future.delayed(
-      delay,
-      () {
-        if (!_pendingNotifications.contains(item)) {
-          return;
-        }
-
-        _pendingNotifications.remove(item);
-
-        _notifications.insert(0, item);
-
-        _listGlobalKey.currentState?.insertItem(
-          0,
-          duration: _createAnimationDuration(item),
-        );
-      },
-    );
-
-    // TODO(payam): add limit count feature
+      // Schedule the insertion after the overlay has been built.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _insertPendingItems();
+      });
+    } else {
+      // Overlay already exists; insert the item immediately.
+      _insertItem(entry);
+    }
 
     return item;
   }
 
-  /// Finds the [ToastificationItem] with the given [id].
-  ToastificationItem? findToastificationItem(String id) {
-    try {
-      return _notifications
-          .firstWhereOrNull((notification) => notification.id == id);
-    } catch (e) {
-      return null;
+  /// Inserts all pending items into the UI.
+  void _insertPendingItems() {
+    if (_dismissAllCalled) {
+      // If dismissAll was called, do not insert pending items.
+      return;
+    }
+
+    for (final entry in _notificationsMap.values.toList()) {
+      if (!entry.isInserted) {
+        _insertItem(entry);
+      }
     }
   }
 
-  /// using this method you can remove a notification item
-  /// if there is no notification in the notification list,
-  /// we will remove the overlay entry
+  /// Helper method to insert an item into the UI.
+  void _insertItem(_NotificationEntry entry) {
+    // Check if dismissAll was called after scheduling the insertion.
+    if (_dismissAllCalled) {
+      _notificationsMap.remove(entry.item.id);
+      return;
+    }
+
+    if (entry.isInserted) {
+      // Already inserted.
+      return;
+    }
+
+    entry.isInserted = true;
+
+    const index = 0; // We insert at the top of the list.
+
+    _listGlobalKey.currentState?.insertItem(
+      index,
+      duration: _createAnimationDuration(entry.item),
+    );
+  }
+
+  /// Finds the [ToastificationItem] with the given [id].
+  ToastificationItem? findToastificationItem(String id) {
+    return _notificationsMap[id]?.item;
+  }
+
+  /// Using this method, you can remove a notification item.
+  /// If there is no notification in the notification map,
+  /// we will remove the overlay entry if necessary.
   ///
-  /// if the [showRemoveAnimation] is true, we will show the remove animation
+  /// If the [showRemoveAnimation] is true, we will show the remove animation
   /// of the [notification] item.
-  /// otherwise we will remove the notification without showing any animation.
-  /// this is useful when you want to remove the notification manually,
-  /// like when you have some [Dismissible] widget
+  /// Otherwise, we will remove the notification without showing any animation.
   void dismiss(
     ToastificationItem notification, {
     bool showRemoveAnimation = true,
   }) {
-    // Remove from pending notifications if it's there
-    _pendingNotifications.remove(notification);
+    final entry = _notificationsMap[notification.id];
 
-    final index = _notifications.indexOf(notification);
-    // print("Toastification Manager Dismiss Notifications: $_notifications");
-    if (index != -1) {
-      notification = _notifications[index];
+    if (entry != null && entry.isInserted) {
+      // Get the index before removing the entry from the map.
+      final index = _getItemIndex(entry);
 
-      if (notification.isRunning) {
-        notification.stop();
+      // Now it's safe to remove the entry from the map.
+      _notificationsMap.remove(notification.id);
+
+      if (index != null && index >= 0) {
+        if (notification.isRunning) {
+          notification.stop();
+        }
+
+        // Remove the item from the AnimatedList.
+        if (showRemoveAnimation) {
+          _listGlobalKey.currentState?.removeItem(
+            index,
+            (BuildContext context, Animation<double> animation) {
+              return ToastHolderWidget(
+                item: notification,
+                animation: animation,
+                alignment: alignment,
+                transformerBuilder: _toastAnimationBuilder(notification),
+              );
+            },
+            duration: _createAnimationDuration(notification),
+          );
+        } else {
+          _listGlobalKey.currentState?.removeItem(
+            index,
+            (BuildContext context, Animation<double> animation) {
+              return const SizedBox.shrink();
+            },
+          );
+        }
+
+        // Check if there are any inserted notifications left.
+        if (_notificationsMap.values.where((e) => e.isInserted).isEmpty) {
+          Future.delayed(
+            (notification.animationDuration ?? config.animationDuration) +
+                _removeOverlayDelay,
+            () {
+              if (_notificationsMap.values.where((e) => e.isInserted).isEmpty) {
+                _overlayEntry?.remove();
+                _overlayEntry = null;
+                _dismissAllCalled = false; // Reset the flag for future toasts.
+              }
+            },
+          );
+        }
       }
-
-      final removedItem = _notifications.removeAt(index);
-
-      /// if the [showRemoveAnimation] is true, we will show the remove animation
-      /// of the notification.
-      if (showRemoveAnimation) {
-        _listGlobalKey.currentState?.removeItem(
-          index,
-          (BuildContext context, Animation<double> animation) {
-            return ToastHolderWidget(
-              item: removedItem,
-              animation: animation,
-              alignment: alignment,
-              transformerBuilder: _toastAnimationBuilder(removedItem),
-            );
-          },
-          duration: _createAnimationDuration(removedItem),
-        );
-
-        /// if the [showRemoveAnimation] is false, we will remove the notification
-        /// without showing the remove animation.
-      } else {
-        _listGlobalKey.currentState?.removeItem(
-          index,
-          (BuildContext context, Animation<double> animation) {
-            return const SizedBox.shrink();
-          },
-        );
-      }
-
-      /// we will remove the [_overlayEntry] if there are no notifications
-      /// We need to check if the _notifications list is empty twice.
-      /// To make sure after the delay, there are no new notifications added.
-      if (_notifications.isEmpty) {
-        Future.delayed(
-          (removedItem.animationDuration ?? config.animationDuration) +
-              _removeOverlayDelay,
-          () {
-            if (_notifications.isEmpty) {
-              _overlayEntry?.remove();
-              _overlayEntry = null;
-            }
-          },
-        );
-      }
+    } else if (entry != null && !entry.isInserted) {
+      // The notification was pending and not yet inserted.
+      // Remove it from the map.
+      _notificationsMap.remove(notification.id);
+      // No UI removal needed.
     }
   }
 
-  /// This function dismisses all the notifications in the [_notifications] list.
+  /// Helper method to get the index of an inserted item.
+  int? _getItemIndex(_NotificationEntry entry) {
+    final entries = _notificationsMap.values.where((e) => e.isInserted).toList()
+      ..sort((a, b) => a.item.id.compareTo(b.item.id));
+    return entries.indexOf(entry);
+  }
+
+  /// This function dismisses all the notifications.
   /// The [delayForAnimation] parameter is optional and defaults to true.
   /// When it is true, it adds a delay for better animation.
   void dismissAll({bool delayForAnimation = true}) async {
+    // Set the flag to indicate that dismissAll has been called.
+    _dismissAllCalled = true;
 
-    _pendingNotifications.clear();
+    // Copy the entries to avoid concurrent modification issues.
+    final entriesToDismiss = _notificationsMap.values.toList();
 
-    // Creates a new list cloneList that has all the notifications from the _notifications list, but in reverse order.
-    final cloneList = _notifications.toList(growable: false).reversed;
-
-    // For each cloned "toastItem" notification in "cloneList",
-    // we will remove it and then pause for a duration if delayForAnimation is true.
-    for (final toastItem in cloneList) {
-      /// If the item is still in the [_notification] list, we will remove it
-      if (findToastificationItem(toastItem.id) != null) {
-        // Dismiss the current notification item
-        dismiss(toastItem);
-
-        // If delayForAnimation is true, wait for 150ms before proceeding to the next item
-        if (delayForAnimation) {
-          await Future.delayed(const Duration(milliseconds: 150));
-        }
+    for (final entry in entriesToDismiss) {
+      // Dismiss each notification.
+      dismiss(entry.item);
+      if (delayForAnimation) {
+        await Future.delayed(const Duration(milliseconds: 150));
       }
+    }
+
+    // Clear the map after dismissing all notifications.
+    _notificationsMap.clear();
+  }
+
+  /// Remove the first notification in the list.
+  void dismissFirst() {
+    final entries =
+        _notificationsMap.values.where((e) => e.isInserted).toList();
+    if (entries.isNotEmpty) {
+      dismiss(entries.first.item);
     }
   }
 
-  /// remove the first notification in the list.
-  void dismissFirst() {
-    dismiss(_notifications.first);
-  }
-
-  /// remove the last notification in the list.
+  /// Remove the last notification in the list.
   void dismissLast() {
-    dismiss(_notifications.last);
+    final entries =
+        _notificationsMap.values.where((e) => e.isInserted).toList();
+    if (entries.isNotEmpty) {
+      dismiss(entries.last.item);
+    }
   }
 
   void _createNotificationHolder(OverlayState overlay) {
@@ -226,7 +259,7 @@ class ToastificationManager {
     overlay.insert(_overlayEntry!);
   }
 
-  /// create a [OverlayEntry] as holder of the notifications
+  /// Create an [OverlayEntry] as holder of the notifications.
   OverlayEntry _createOverlayEntry() {
     return OverlayEntry(
       opaque: false,
@@ -245,7 +278,8 @@ class ToastificationManager {
               child: AnimatedList(
                 key: _listGlobalKey,
                 clipBehavior: config.clipBehavior,
-                initialItemCount: _notifications.length,
+                initialItemCount:
+                    _notificationsMap.values.where((e) => e.isInserted).length,
                 reverse: alignment.y >= 0,
                 primary: true,
                 shrinkWrap: true,
@@ -254,7 +288,11 @@ class ToastificationManager {
                   int index,
                   Animation<double> animation,
                 ) {
-                  final item = _notifications[index];
+                  final entries = _notificationsMap.values
+                      .where((e) => e.isInserted)
+                      .toList();
+                  final entry = entries[index];
+                  final item = entry.item;
 
                   return ToastHolderWidget(
                     item: item,
@@ -284,8 +322,8 @@ class ToastificationManager {
       marginValue = marginValue.add(MediaQuery.of(context).viewInsets);
     }
 
-    /// Add the MediaQuery viewPadding as margin so other widgets behind the toastification overlay
-    /// will be touchable and not covered by the toastification overlay.
+    // Add the MediaQuery viewPadding as margin so other widgets behind the toastification overlay
+    // will be touchable and not covered by the toastification overlay.
     return marginValue.add(MediaQuery.of(context).viewPadding);
   }
 


### PR DESCRIPTION
This PR fixes an issue where toasts that are scheduled to appear (pending toasts) are still displayed even after `dismiss` or `dismissAll` is called before they are shown.

**Changes Made:**

- **Single Data Structure for Notifications:**
  - Utilized a single `_notificationsMap` to manage both pending and shown notifications.
  - Each notification entry now includes an `isInserted` flag to track its display status.
  
- **Pending Status Management:**
  - Notifications are added to `_notificationsMap` immediately with a pending status.
  - After the overlay is ready, the status is updated, and pending notifications are inserted into the UI.
  
- **Dismissal Logic Enhancement:**
  - Modified `dismiss` and `dismissAll` methods to check and update the status of notifications.
  - Ensured that pending notifications are not shown if they have been dismissed before insertion.
  
- **Preventing Delayed Toasts After Dismissal:**
  - Introduced a `_dismissAllCalled` flag to prevent insertion of pending toasts after `dismissAll` is invoked.
  - Adjusted insertion methods to respect the dismissal state and avoid displaying dismissed toasts.
  
close #119 