### PR TITLE
fix: ensure scrollbar reaches screen edge on large screens by applying maxWidth constraints locally

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -39,7 +39,6 @@ class ToastificationApp extends ConsumerWidget {
         builder: (context, child) {
           return ResponsiveWrapper.builder(
             child,
-            maxWidth: 1350,
             minWidth: 300,
             defaultScale: false,
             breakpoints: [

--- a/example/lib/src/core/usecase/responsive/responsive.dart
+++ b/example/lib/src/core/usecase/responsive/responsive.dart
@@ -3,6 +3,8 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
+const kMaxWidth = 1350.0;
+
 const smallMobileBreakpointTag = 'Small-Mobile';
 const mobileBreakpointTag = 'Mobile';
 const tabletBreakpointTag = 'Tablet';

--- a/example/lib/src/features/home/views/pages/home.dart
+++ b/example/lib/src/features/home/views/pages/home.dart
@@ -33,19 +33,24 @@ class _HomeScreenState extends State<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scrollbar(
-      child: Scaffold(
-        extendBody: true,
-        bottomNavigationBar: const BottomNavigationView(),
-        body: CustomScrollView(
-          scrollBehavior: const ScrollBehavior().copyWith(
-            scrollbars: false,
+      child: Center(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: kMaxWidth),
+          child: Scaffold(
+            extendBody: true,
+            bottomNavigationBar: const BottomNavigationView(),
+            body: CustomScrollView(
+              scrollBehavior: const ScrollBehavior().copyWith(
+                scrollbars: false,
+              ),
+              primary: true,
+              slivers: const [
+                ToastAppBar(),
+                SliverToBoxAdapter(child: ToastHeader()),
+                CustomizationSection(),
+              ],
+            ),
           ),
-          primary: true,
-          slivers: const [
-            ToastAppBar(),
-            SliverToBoxAdapter(child: ToastHeader()),
-            CustomizationSection(),
-          ],
         ),
       ),
     );


### PR DESCRIPTION
- Moved maxWidth constraint from ResponsiveWrapper.builder to a constant (kMaxWidth) in responsive.dart.
- Applied maxWidth constraint only to the main content instead of globally, allowing the scrollbar to take full width.
- Fixed scrollbar visibility issue on large screens while maintaining content width constraints.

### Before:

![How it looked before](https://github.com/user-attachments/assets/35c447a2-ce14-44eb-b6ea-a764bd1fca3c)

### After:

![How it looks after PR](https://github.com/user-attachments/assets/dac23f5e-57f4-4eb6-8550-aea1e0b4a464)
