### PR TITLE
Fix: Update deprecated Color alpha access in ColorUtils for Flutter 3.16+

### DIFF
--- a/lib/src/utils/color_utils.dart
+++ b/lib/src/utils/color_utils.dart
@@ -68,13 +68,13 @@ extension IntColorComponents on Color {
   int get intAlpha => alpha;
 
   /// Red component as an 8-bit integer (0-255)
-  int get intRed => _floatToInt8(r);
+  int get intRed => red;
 
   /// Green component as an 8-bit integer (0-255)
-  int get intGreen => _floatToInt8(g);
+  int get intGreen => green;
 
   /// Blue component as an 8-bit integer (0-255)
-  int get intBlue => _floatToInt8(b);
+  int get intBlue => blue;
 
   /// Complete color value as a 32-bit integer in ARGB format
   int get intValue => intAlpha << 24 | intRed << 16 | intGreen << 8 | intBlue;

--- a/lib/src/utils/color_utils.dart
+++ b/lib/src/utils/color_utils.dart
@@ -65,7 +65,7 @@ class ColorUtils {
 /// and retrieve the complete color value as a 32-bit integer.
 extension IntColorComponents on Color {
   /// Alpha component as an 8-bit integer (0-255)
-  int get intAlpha => _floatToInt8(a);
+  int get intAlpha => alpha;
 
   /// Red component as an 8-bit integer (0-255)
   int get intRed => _floatToInt8(r);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ topics:
 
 environment:
   sdk: ">=3.0.0 <4.0.0"
-  flutter: ">=3.27.0"
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## What Changed
- Replaced deprecated `Color.a` getter with `Color.alpha`
- Updated `r`, `g`, and `b` to use `.red`, `.green`, and `.blue` respectively
- Removed unnecessary `_floatToInt8()` conversions since current Flutter `Color` components return integer values

## Why This Matters
Flutter 3.16 deprecated access to `Color.a`, `Color.r`, `Color.g`, and `Color.b`. This caused build failures in projects using `toastification`. This PR brings the package up-to-date with the latest Flutter versions and resolves these errors.

## Additional Notes
- No breaking changes introduced
- Tested with Flutter 3.16.3 stable

Let me know if any adjustments are needed or if you'd prefer this change in a different branch format. Happy to collaborate further!
