### PR TITLE
feat: provide blockBackgroundInteraction parameter method

### DIFF
--- a/lib/src/core/toastification.dart
+++ b/lib/src/core/toastification.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:toastification/src/built_in/built_in_builder.dart';
 import 'package:toastification/src/core/toastification_manager.dart';
 import 'package:toastification/src/core/toastification_overlay_state.dart';
-import 'package:toastification/src/built_in/built_in_builder.dart';
 import 'package:toastification/toastification.dart';
 
 // TODO(payam): add navigator observer
@@ -123,6 +123,7 @@ class Toastification {
     OverlayState? overlayState,
     DismissDirection? dismissDirection,
     ToastificationCallbacks callbacks = const ToastificationCallbacks(),
+    bool? blockBackgroundInteraction,
   }) {
     context ??= overlayState?.context;
 
@@ -168,6 +169,7 @@ class Toastification {
       autoCloseDuration: autoCloseDuration,
       overlayState: overlayState!,
       callbacks: callbacks,
+      blockBackgroundInteraction: blockBackgroundInteraction,
     );
   }
 
@@ -200,6 +202,7 @@ class Toastification {
     ToastificationAnimationBuilder? animationBuilder,
     Duration? animationDuration,
     Duration? autoCloseDuration,
+    bool? blockBackgroundInteraction,
     ToastificationCallbacks callbacks = const ToastificationCallbacks(),
   }) {
     final context = navigator.context;
@@ -214,6 +217,7 @@ class Toastification {
       autoCloseDuration: autoCloseDuration,
       overlayState: navigator.overlay,
       callbacks: callbacks,
+      blockBackgroundInteraction: blockBackgroundInteraction,
     );
   }
 
@@ -271,6 +275,7 @@ class Toastification {
     DismissDirection? dismissDirection,
     bool? pauseOnHover,
     bool? applyBlurEffect,
+    bool? blockBackgroundInteraction,
     ToastificationCallbacks callbacks = const ToastificationCallbacks(),
   }) {
     // TODO: remove this variable when the deprecated parameter (closeButtonShowType) is removed
@@ -289,6 +294,7 @@ class Toastification {
       animationBuilder: animationBuilder,
       animationDuration: animationDuration,
       callbacks: callbacks,
+      blockBackgroundInteraction: blockBackgroundInteraction,
       builder: (context, holder) {
         return BuiltInBuilder(
           item: holder,

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:collection/collection.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:toastification/src/core/widget/toast_builder.dart';
 import 'package:toastification/toastification.dart';
@@ -50,6 +50,7 @@ class ToastificationManager {
     required Duration? animationDuration,
     required ToastificationCallbacks callbacks,
     Duration? autoCloseDuration,
+    bool? blockBackgroundInteraction,
   }) {
     final item = ToastificationItem(
       builder: builder,
@@ -64,7 +65,7 @@ class ToastificationManager {
     );
 
     if (overlayEntry == null) {
-      _createNotificationHolder(overlayState);
+      _createNotificationHolder(overlayState, blockBackgroundInteraction);
     }
 
     scheduler.addPostFrameCallback((_) {
@@ -200,13 +201,13 @@ class ToastificationManager {
     dismiss(notifications.last);
   }
 
-  void _createNotificationHolder(OverlayState overlay) {
-    overlayEntry = _createOverlayEntry();
+  void _createNotificationHolder(OverlayState overlay, bool? blockBackgroundInteraction) {
+    overlayEntry = _createOverlayEntry(blockBackgroundInteraction);
     overlay.insert(overlayEntry!);
   }
 
   /// create a [OverlayEntry] as holder of the notifications
-  OverlayEntry _createOverlayEntry() {
+  OverlayEntry _createOverlayEntry([bool? blockBackgroundInteraction]) {
     return OverlayEntry(
       opaque: false,
       builder: (context) {
@@ -247,7 +248,10 @@ class ToastificationManager {
           ),
         );
 
-        if (config.blockBackgroundInteraction) {
+        // Use the provided blockBackgroundInteraction value if available, otherwise use the config value
+        final shouldBlockBackgroundInteraction = blockBackgroundInteraction ?? config.blockBackgroundInteraction;
+
+        if (shouldBlockBackgroundInteraction) {
           return GestureDetector(
             behavior: HitTestBehavior.opaque,
             child: overlay,
@@ -280,6 +284,5 @@ class ToastificationManager {
   ) =>
       item.animationBuilder ?? config.animationBuilder;
 
-  Duration _createAnimationDuration(ToastificationItem item) =>
-      item.animationDuration ?? config.animationDuration;
+  Duration _createAnimationDuration(ToastificationItem item) => item.animationDuration ?? config.animationDuration;
 }


### PR DESCRIPTION
Use the provided blockBackgroundInteraction value if available, otherwise use the config value

This is very important. If it is set through config, it becomes a global setting and cannot be customized. In fact, users only need to block the interaction when loading.