### PR TITLE
fix: dispose overlay and value listener after animation remove

### DIFF
--- a/example/lib/src/core/views/widgets/drop_down.dart
+++ b/example/lib/src/core/views/widgets/drop_down.dart
@@ -78,7 +78,7 @@ class BorderedDropDown<T> extends StatelessWidget {
                 ],
               )
             : null,
-        value: value,
+        initialValue: value,
         items: items,
         onChanged: available ? onChanged : null,
         selectedItemBuilder: (context) {

--- a/lib/src/core/toastification_item.dart
+++ b/lib/src/core/toastification_item.dart
@@ -177,4 +177,9 @@ class ToastificationItem implements Equatable {
 
   @override
   bool? get stringify => false;
+
+  void dispose() {
+    stop();
+    _timeStatus.dispose();
+  }
 }

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -122,9 +122,15 @@ class ToastificationManager {
 
       final removedItem = notifications.removeAt(index);
 
+      Duration delay = removeOverlayDelay;
+
       /// if the [showRemoveAnimation] is true, we will show the remove animation
       /// of the notification.
       if (showRemoveAnimation) {
+        final animationDuration = _createAnimationDuration(removedItem);
+
+        delay = animationDuration + delay;
+
         listGlobalKey.currentState?.removeItem(
           index,
           (BuildContext context, Animation<double> animation) {
@@ -135,7 +141,7 @@ class ToastificationManager {
               transformerBuilder: _toastAnimationBuilder(removedItem),
             );
           },
-          duration: _createAnimationDuration(removedItem),
+          duration: animationDuration,
         );
 
         /// if the [showRemoveAnimation] is false, we will remove the notification
@@ -149,16 +155,21 @@ class ToastificationManager {
         );
       }
 
+      // Always dispose the item after the delay value notifier and timer can cause leaks memory.
+      Future.delayed(delay, () {
+        removedItem.dispose();
+      });
+
       /// we will remove the [_overlayEntry] if there are no notifications
       /// We need to check if the _notifications list is empty twice.
       /// To make sure after the delay, there are no new notifications added.
       if (notifications.isEmpty) {
         Future.delayed(
-          (removedItem.animationDuration ?? config.animationDuration) +
-              removeOverlayDelay,
+          delay,
           () {
             if (notifications.isEmpty) {
               overlayEntry?.remove();
+              overlayEntry?.dispose();
               overlayEntry = null;
             }
           },

--- a/test/src/core/toastification_item_test.dart
+++ b/test/src/core/toastification_item_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 import 'package:toastification/toastification.dart';
 
 void main() {

--- a/test/src/core/toastification_item_test.dart
+++ b/test/src/core/toastification_item_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:toastification/toastification.dart';
 
 void main() {
@@ -188,6 +189,36 @@ void main() {
       expect(
         toastification.toString(),
         contains('timerDuration: ${toastification.originalDuration}'),
+      );
+    });
+  });
+
+  group('Dispose', () {
+    test('dispose stops the timer and disposes the time status notifier', () {
+      toastification = ToastificationItem(
+        builder: mockBuilder,
+        alignment: Alignment.topCenter,
+        autoCloseDuration: const Duration(seconds: 2),
+      );
+
+      expect(toastification.timeStatus, ToastTimeStatus.started);
+
+      toastification.dispose();
+
+      expect(toastification.timeStatus, ToastTimeStatus.stopped);
+    });
+
+    test('adding listener after dispose throws', () {
+      toastification = ToastificationItem(
+        builder: mockBuilder,
+        alignment: Alignment.topCenter,
+      );
+
+      toastification.dispose();
+
+      expect(
+        () => toastification.addListenerOnTimeStatus(() {}),
+        throwsFlutterError,
       );
     });
   });

--- a/test/src/core/toastification_manager_test.dart
+++ b/test/src/core/toastification_manager_test.dart
@@ -481,6 +481,36 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets('should dispose item after dismiss animation completes',
+        (WidgetTester tester) async {
+      await createOverlay(tester);
+
+      final item = manager.showCustom(
+        overlayState: overlayState,
+        scheduler: tester.binding,
+        builder: (context, item) => const Text('Test Toast'),
+        animationBuilder: null,
+        animationDuration: const Duration(milliseconds: 100),
+        autoCloseDuration: const Duration(seconds: 2),
+        callbacks: const ToastificationCallbacks(),
+      );
+
+      await tester.pumpAndSettle();
+
+      manager.dismiss(item);
+
+      // Wait for animation duration + removeOverlayDelay
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(manager.removeOverlayDelay);
+
+      // After the delay, the item should be disposed —
+      // adding a listener to a disposed ValueNotifier throws
+      expect(
+        () => item.addListenerOnTimeStatus(() {}),
+        throwsFlutterError,
+      );
+    });
+
     testWidgets('should do nothing when dismissing non-existent notification',
         (WidgetTester tester) async {
       await createOverlay(tester);


### PR DESCRIPTION
- ValueNotifier and Overlay must be disposed after the use, only set the object as null can cause memory leak, added call to dispose on valueNotifier and overlay after the animation finished.
- Memory leak found when writing some tests that calls toastification, even with a pump duration of 10 seconds the leak on tear down still happens.

```
Expected: leak free
  Actual: <Instance of 'Leaks'>
   Which: contains leaks:
          # The text is generated by leak_tracker.
          # For leak troubleshooting tips open:
          # https://github.com/dart-lang/leak_tracker/blob/main/doc/leak_tracking/TROUBLESHOOT.md
          notDisposed:
            total: 3
            objects:
              OverlayEntry:
                test: should call onDenied when seller does not have permission
                identityHashCode: 1020958747
              ValueNotifier<_OverlayEntryWidgetState?>:
                test: should call onDenied when seller does not have permission
                identityHashCode: 1027573
              ValueNotifier<ToastTimeStatus>:
                test: should call onDenied when seller does not have permission
                identityHashCode: 200919537
          
          

package:matcher                                              expect
package:leak_tracker_testing/src/leak_testing.dart 69:24     LeakTesting.collectedLeaksReporter.<fn>
package:leak_tracker_flutter_testing/src/testing.dart 72:37  maybeTearDownLeakTrackingForAll
===== asynchronous gap ===========================
dart:async                                                   _CustomZone.registerBinaryCallback
package:flutter_test/src/test_compat.dart 302:3              _tearDownForTestFile
```