### PR TITLE
fix: Resolve toast block by Overlay breaking change (Flutter 3.38+)

### DIFF
--- a/lib/src/core/toastification.dart
+++ b/lib/src/core/toastification.dart
@@ -130,7 +130,7 @@ class Toastification {
 
     if (contextProvided) {
       direction ??= Directionality.of(context!);
-      overlayState ??= Overlay.maybeOf(context!, rootOverlay: true);
+      overlayState ??= context!.findAncestorStateOfType<OverlayState>();
     }
 
     /// if context isn't provided


### PR DESCRIPTION
In Flutter 3.38 and later versions, there is a breaking change to `Overlay.of`/`Overlay.maybeOf` that prevents toasts popped up using `BuildContext`/`GlobalNavigatorKey` from working properly.

References:
[Deprecate `OverlayPortal.targetsRootOverlay` and enforce `LookupBoundary` in `Overlay.of`](https://docs.flutter.dev/release/breaking-changes/deprecate-overlay-portal-targets-root#summary)
[Breaking change on 3.38.1: Overlay.of(context) throws 'No Overlay widget found'](https://github.com/flutter/flutter/issues/178600#issuecomment-3580877721)