### PR TITLE
fix: remove item instantly when showRemoveAnimation is false

### DIFF
--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -122,38 +122,30 @@ class ToastificationManager {
 
       final removedItem = notifications.removeAt(index);
 
-      Duration delay = removeOverlayDelay;
+      // Pass Duration.zero when showRemoveAnimation is false. Omitting duration
+      // uses AnimatedList's 300ms default while overlay teardown still uses
+      // removeOverlayDelay (50ms), which can double-dispose the controller.
+      final Duration removeDuration = showRemoveAnimation
+          ? _createAnimationDuration(removedItem)
+          : Duration.zero;
+      final Duration delay = removeDuration + removeOverlayDelay;
 
-      /// if the [showRemoveAnimation] is true, we will show the remove animation
-      /// of the notification.
-      if (showRemoveAnimation) {
-        final animationDuration = _createAnimationDuration(removedItem);
-
-        delay = animationDuration + delay;
-
-        listGlobalKey.currentState?.removeItem(
-          index,
-          (BuildContext context, Animation<double> animation) {
-            return ToastHolderWidget(
-              item: removedItem,
-              animation: animation,
-              alignment: alignment,
-              transformerBuilder: _toastAnimationBuilder(removedItem),
-            );
-          },
-          duration: animationDuration,
-        );
-
-        /// if the [showRemoveAnimation] is false, we will remove the notification
-        /// without showing the remove animation.
-      } else {
-        listGlobalKey.currentState?.removeItem(
-          index,
-          (BuildContext context, Animation<double> animation) {
+      listGlobalKey.currentState?.removeItem(
+        index,
+        (BuildContext context, Animation<double> animation) {
+          if (!showRemoveAnimation) {
             return const SizedBox.shrink();
-          },
-        );
-      }
+          }
+
+          return ToastHolderWidget(
+            item: removedItem,
+            animation: animation,
+            alignment: alignment,
+            transformerBuilder: _toastAnimationBuilder(removedItem),
+          );
+        },
+        duration: removeDuration,
+      );
 
       // Always dispose the item after the delay value notifier and timer can cause leaks memory.
       Future.delayed(delay, () {

--- a/test/src/core/toastification_manager_test.dart
+++ b/test/src/core/toastification_manager_test.dart
@@ -481,6 +481,34 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets(
+        'should remove instantly when showRemoveAnimation is false',
+        (WidgetTester tester) async {
+      await createOverlay(tester);
+
+      final item = manager.showCustom(
+        overlayState: overlayState,
+        scheduler: tester.binding,
+        builder: (context, item) => const Text('Test Toast'),
+        animationBuilder: null,
+        animationDuration: const Duration(seconds: 1),
+        callbacks: const ToastificationCallbacks(),
+      );
+
+      await tester.pumpAndSettle();
+      expect(tester.binding.transientCallbackCount, isZero);
+
+      manager.dismiss(item, showRemoveAnimation: false);
+      await tester.pump();
+
+      // No AnimatedList removal animation should remain after an instant dismiss.
+      expect(tester.binding.transientCallbackCount, isZero);
+
+      await tester.pump(manager.removeOverlayDelay);
+      expect(manager.overlayEntry, isNull);
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('should dispose item after dismiss animation completes',
         (WidgetTester tester) async {
       await createOverlay(tester);


### PR DESCRIPTION
## Problem

When a toast is dismissed with `showRemoveAnimation: false`, `ToastificationManager.dismiss` called `AnimatedListState.removeItem` **without** a `duration`:
```dart
listGlobalKey.currentState?.removeItem(
  index,
  (BuildContext context, Animation<double> animation) {
    return const SizedBox.shrink();
  },
);
```
`removeItem` then falls back to its own default of `_kDuration (300ms)`, so the removal is not instant despite the flag. 

Meanwhile, delay stayed at `removeOverlayDelay (50ms)`, and that same delay drives the overlay teardown:

```dart
Future.delayed(delay, () {
  if (notifications.isEmpty) {
    overlayEntry?.remove();
    overlayEntry?.dispose();
    overlayEntry = null;
  }
});
```

The two are therefore desynchronized by 250ms: when the last toast is swiped away, the `OverlayEntry` (and with it the `AnimatedList`) is disposed at 50ms while the removal animation still has ~250ms to run.

**Consequences:**
* `showRemoveAnimation: false` does not behave as documented. It runs a 300ms removal animation.
* The `AnimatedList` is disposed mid-removal. 

## Fix
Derive a single `removeDuration` and use it for both `removeItem` and the teardown delay, so the two can no longer drift apart:

```dart
final Duration removeDuration = showRemoveAnimation
    ? _createAnimationDuration(removedItem)
    : Duration.zero;
final Duration delay = removeDuration + removeOverlayDelay;
```

`Duration.zero` makes `removeItem` finalize in the next microtask, which both honours the flag's contract and closes the teardown race for this path. 

The two `removeItem` call sites are merged into one, with the builder choosing between `SizedBox.shrink()` and `ToastHolderWidget`.

**Behaviour**
* `showRemoveAnimation: true` — unchanged (same duration, same delay).
* `showRemoveAnimation: false` — item is now removed instantly, as documented. `removedItem.dispose()` and the overlay teardown still happen after `removeOverlayDelay`, exactly as before.

## Tests
Added a regression test to dismiss asserting no removal animation is left running after a `showRemoveAnimation: false` dismiss and that the overlay is torn down cleanly without exceptions.