### PR TITLE
feat: update compatibility with Flutter 3.47.1

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,4 +1,4 @@
 {
-  "flutter": "3.41.5",
+  "flutter": "3.47.1",
   "flavors": {}
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:example/src/core/usecase/responsive/responsive.dart';
 import 'package:example/src/features/home/views/pages/home.dart';
 import 'package:example/src/theme/theme.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:responsive_framework/responsive_framework.dart';

--- a/example/lib/src/core/usecase/responsive/responsive.dart
+++ b/example/lib/src/core/usecase/responsive/responsive.dart
@@ -1,6 +1,6 @@
 import 'dart:developer';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
 const kMaxWidth = 1350.0;

--- a/example/lib/src/core/views/code/code_viewer.dart
+++ b/example/lib/src/core/views/code/code_viewer.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:highlight/highlight.dart' show highlight, Node;
 
 /// Highlight Flutter Widget

--- a/example/lib/src/core/views/widgets/border_holder.dart
+++ b/example/lib/src/core/views/widgets/border_holder.dart
@@ -1,5 +1,5 @@
 import 'package:example/src/core/usecase/responsive/responsive.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const topHolderPadding = EdgeInsets.fromLTRB(40, 40, 40, 32);
 const middleHolderPadding = EdgeInsets.fromLTRB(40, 32, 40, 32);

--- a/example/lib/src/core/views/widgets/bordered_container.dart
+++ b/example/lib/src/core/views/widgets/bordered_container.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BorderedContainer extends StatelessWidget {
   const BorderedContainer({

--- a/example/lib/src/core/views/widgets/bottom_navigation.dart
+++ b/example/lib/src/core/views/widgets/bottom_navigation.dart
@@ -1,7 +1,7 @@
 import 'package:example/src/core/usecase/responsive/responsive.dart';
 import 'package:example/src/features/home/controllers/toast_detail.dart';
 import 'package:example/src/features/home/views/ui_states/extra.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_flutter/iconsax_flutter.dart';
 import 'package:toastification/toastification.dart';

--- a/example/lib/src/core/views/widgets/core.dart
+++ b/example/lib/src/core/views/widgets/core.dart
@@ -1,5 +1,6 @@
 import 'package:example/src/core/usecase/responsive/responsive.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class ColoredTag extends StatelessWidget {
   const ColoredTag({
@@ -11,7 +12,7 @@ class ColoredTag extends StatelessWidget {
   });
 
   final String text;
-  final IconData? icon;
+  final FaIconData? icon;
   final Color? background;
   final Color? foreground;
 
@@ -39,7 +40,7 @@ class ColoredTag extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          Icon(
+          FaIcon(
             icon,
             size: context.responsiveValue(
               desktop: 24,

--- a/example/lib/src/core/views/widgets/count_tile.dart
+++ b/example/lib/src/core/views/widgets/count_tile.dart
@@ -1,5 +1,5 @@
 import 'package:example/src/core/views/widgets/bordered_container.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class CountTile extends StatelessWidget {
   const CountTile({

--- a/example/lib/src/core/views/widgets/divider.dart
+++ b/example/lib/src/core/views/widgets/divider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class FlexDivider extends StatelessWidget {
   const FlexDivider({

--- a/example/lib/src/core/views/widgets/drop_down.dart
+++ b/example/lib/src/core/views/widgets/drop_down.dart
@@ -1,5 +1,5 @@
 import 'package:example/src/core/views/widgets/soon.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class BorderedDropDown<T> extends StatelessWidget {
   const BorderedDropDown({

--- a/example/lib/src/core/views/widgets/expandable_section.dart
+++ b/example/lib/src/core/views/widgets/expandable_section.dart
@@ -1,5 +1,5 @@
 import 'package:example/src/core/views/widgets/expandable_widget.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ExpandableSection extends StatefulWidget {
   const ExpandableSection({

--- a/example/lib/src/core/views/widgets/expandable_widget.dart
+++ b/example/lib/src/core/views/widgets/expandable_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 typedef ExpandableWidgetCallback = void Function(bool isExpanded);
 

--- a/example/lib/src/core/views/widgets/picker/alignment.dart
+++ b/example/lib/src/core/views/widgets/picker/alignment.dart
@@ -1,5 +1,5 @@
 import 'package:example/src/core/views/widgets/bordered_container.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class AlignmentPicker extends StatelessWidget {
   const AlignmentPicker(

--- a/example/lib/src/core/views/widgets/picker/border_radius.dart
+++ b/example/lib/src/core/views/widgets/picker/border_radius.dart
@@ -1,5 +1,5 @@
 import 'package:example/src/core/views/widgets/bordered_container.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 final borderRadiusValues = {
   'Sharp': BorderRadius.circular(4),

--- a/example/lib/src/core/views/widgets/picker/color.dart
+++ b/example/lib/src/core/views/widgets/picker/color.dart
@@ -1,5 +1,5 @@
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 import '../bordered_container.dart';
 

--- a/example/lib/src/core/views/widgets/picker/elevation.dart
+++ b/example/lib/src/core/views/widgets/picker/elevation.dart
@@ -1,7 +1,7 @@
 import 'package:example/src/core/usecase/responsive/responsive.dart';
 import 'package:example/src/core/views/widgets/bordered_container.dart';
 import 'package:example/src/features/home/views/ui_states/toast_detail_ui_state.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
 final elevationValues = {

--- a/example/lib/src/core/views/widgets/picker/icon/icon.dart
+++ b/example/lib/src/core/views/widgets/picker/icon/icon.dart
@@ -2,7 +2,7 @@ import 'package:example/src/core/views/widgets/bordered_container.dart';
 import 'package:example/src/core/views/widgets/picker/icon/icon_provider.dart';
 import 'package:example/src/core/views/widgets/picker/icon/icon_tile.dart';
 import 'package:example/src/features/home/controllers/toast_detail.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:toastification/toastification.dart';
 

--- a/example/lib/src/core/views/widgets/picker/icon/icon_tile.dart
+++ b/example/lib/src/core/views/widgets/picker/icon/icon_tile.dart
@@ -1,6 +1,6 @@
 import 'package:example/src/features/home/controllers/toast_detail.dart';
 import 'package:example/src/features/home/views/ui_states/icon_model.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class IconTile extends ConsumerStatefulWidget {

--- a/example/lib/src/core/views/widgets/picker/toast_style.dart
+++ b/example/lib/src/core/views/widgets/picker/toast_style.dart
@@ -2,7 +2,7 @@ import 'package:example/src/core/views/widgets/bordered_container.dart';
 import 'package:example/src/core/views/widgets/expandable_section.dart';
 import 'package:example/src/core/views/widgets/toggle_tile.dart';
 import 'package:example/src/features/home/controllers/toast_detail.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:toastification/toastification.dart';
 

--- a/example/lib/src/core/views/widgets/soon.dart
+++ b/example/lib/src/core/views/widgets/soon.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class SoonWidget extends StatelessWidget {
   const SoonWidget({super.key});

--- a/example/lib/src/core/views/widgets/toast_type_tab_bar.dart
+++ b/example/lib/src/core/views/widgets/toast_type_tab_bar.dart
@@ -2,7 +2,7 @@ import 'package:example/src/core/usecase/responsive/responsive.dart';
 import 'package:example/src/core/views/widgets/bordered_container.dart';
 import 'package:example/src/core/views/widgets/soon.dart';
 import 'package:example/src/features/home/controllers/toast_detail.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:toastification/toastification.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';

--- a/example/lib/src/core/views/widgets/toggle.dart
+++ b/example/lib/src/core/views/widgets/toggle.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class RoundToggle extends StatelessWidget {
   const RoundToggle({

--- a/example/lib/src/core/views/widgets/toggle_tile.dart
+++ b/example/lib/src/core/views/widgets/toggle_tile.dart
@@ -1,7 +1,7 @@
 import 'package:example/src/core/views/widgets/bordered_container.dart';
 import 'package:example/src/core/views/widgets/soon.dart';
 import 'package:example/src/core/views/widgets/toggle.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class ToggleTile extends StatelessWidget {
   const ToggleTile({

--- a/example/lib/src/database/utils_mapping.dart
+++ b/example/lib/src/database/utils_mapping.dart
@@ -3,7 +3,7 @@ import 'package:example/src/database/database.dart';
 import 'package:example/src/features/home/views/ui_states/animation_type.dart';
 import 'package:example/src/features/home/views/ui_states/icon_model.dart';
 import 'package:example/src/features/home/views/ui_states/toast_detail_ui_state.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 class UtilsMapping {
@@ -160,8 +160,11 @@ class IconMapper {
     final icon = IconModel(
       name: castedMap['name'] ?? 'default_name',
       iconData: IconData(
+        // ignore: non_const_argument_for_const_parameter
         codePoint,
+        // ignore: non_const_argument_for_const_parameter
         fontFamily: fontFamily,
+        // ignore: non_const_argument_for_const_parameter
         fontPackage: fontPackage,
         matchTextDirection: matchTextDirection,
       ),

--- a/example/lib/src/features/home/controllers/toast_detail.dart
+++ b/example/lib/src/features/home/controllers/toast_detail.dart
@@ -6,7 +6,7 @@ import 'package:example/src/database/utils_mapping.dart';
 import 'package:example/src/features/home/views/ui_states/animation_type.dart';
 import 'package:example/src/features/home/views/ui_states/icon_model.dart';
 import 'package:example/src/features/home/views/ui_states/toast_detail_ui_state.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:toastification/toastification.dart';
 

--- a/example/lib/src/features/home/views/pages/home.dart
+++ b/example/lib/src/features/home/views/pages/home.dart
@@ -7,7 +7,7 @@ import 'package:example/src/features/home/views/widgets/customization_panel.dart
 import 'package:example/src/features/home/views/widgets/header.dart';
 import 'package:example/src/features/home/views/widgets/image.dart';
 import 'package:example/src/features/home/views/widgets/preview_panel.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_sticky_header/flutter_sticky_header.dart';
 
 class HomeScreen extends StatefulWidget {

--- a/example/lib/src/features/home/views/ui_states/animation_type.dart
+++ b/example/lib/src/features/home/views/ui_states/animation_type.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 sealed class AnimationType {

--- a/example/lib/src/features/home/views/ui_states/extra.dart
+++ b/example/lib/src/features/home/views/ui_states/extra.dart
@@ -1,6 +1,6 @@
 import 'package:example/src/features/home/views/ui_states/toast_code_formatter.dart';
 import 'package:example/src/features/home/views/ui_states/toast_detail_ui_state.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/services.dart';
 import 'package:toastification/toastification.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/example/lib/src/features/home/views/ui_states/icon_model.dart
+++ b/example/lib/src/features/home/views/ui_states/icon_model.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'icon_model.freezed.dart';

--- a/example/lib/src/features/home/views/ui_states/toast_code_formatter.dart
+++ b/example/lib/src/features/home/views/ui_states/toast_code_formatter.dart
@@ -2,7 +2,7 @@ import 'package:dart_style/dart_style.dart';
 import 'package:example/src/features/home/views/ui_states/animation_type.dart';
 import 'package:example/src/features/home/views/ui_states/toast_detail_ui_state.dart';
 import 'package:flex_color_picker/flex_color_picker.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 class ToastCodeFormatter {

--- a/example/lib/src/features/home/views/ui_states/toast_detail_ui_state.dart
+++ b/example/lib/src/features/home/views/ui_states/toast_detail_ui_state.dart
@@ -1,6 +1,6 @@
 import 'package:example/src/features/home/views/ui_states/animation_type.dart';
 import 'package:example/src/features/home/views/ui_states/icon_model.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:toastification/toastification.dart';
 

--- a/example/lib/src/features/home/views/widgets/app_bar/app_bar.dart
+++ b/example/lib/src/features/home/views/widgets/app_bar/app_bar.dart
@@ -3,7 +3,7 @@ import 'package:example/src/features/home/views/ui_states/extra.dart';
 import 'package:example/src/features/home/views/widgets/app_bar/app_bar_container.dart';
 import 'package:example/src/features/home/views/widgets/app_bar/app_bar_logo.dart';
 import 'package:example/src/features/home/views/widgets/app_bar/app_bar_text_button.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:iconsax_flutter/iconsax_flutter.dart';
 
@@ -81,7 +81,7 @@ class _AppBar extends StatelessWidget {
               onPressed: () {
                 openGithub(context);
               },
-              icon: const Icon(FontAwesomeIcons.github),
+              icon: const FaIcon(FontAwesomeIcons.github),
               label: const Text('Github Source'),
             ),
             gap,

--- a/example/lib/src/features/home/views/widgets/app_bar/app_bar_container.dart
+++ b/example/lib/src/features/home/views/widgets/app_bar/app_bar_container.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class AppBarContainer extends StatelessWidget {
   const AppBarContainer({

--- a/example/lib/src/features/home/views/widgets/app_bar/app_bar_logo.dart
+++ b/example/lib/src/features/home/views/widgets/app_bar/app_bar_logo.dart
@@ -1,6 +1,6 @@
 import 'package:example/src/core/usecase/responsive/responsive.dart';
 import 'package:example/src/features/home/views/widgets/image.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class AppBarLogo extends StatelessWidget {
   const AppBarLogo({super.key});

--- a/example/lib/src/features/home/views/widgets/app_bar/app_bar_text_button.dart
+++ b/example/lib/src/features/home/views/widgets/app_bar/app_bar_text_button.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 class AppBarTextButton extends StatelessWidget {
   final Widget? icon;

--- a/example/lib/src/features/home/views/widgets/content.dart
+++ b/example/lib/src/features/home/views/widgets/content.dart
@@ -4,7 +4,7 @@ import 'package:example/src/core/views/widgets/picker/icon/icon.dart';
 import 'package:example/src/core/views/widgets/soon.dart';
 import 'package:example/src/core/views/widgets/toggle_tile.dart';
 import 'package:example/src/features/home/controllers/toast_detail.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class ContentWidget extends StatelessWidget {

--- a/example/lib/src/features/home/views/widgets/customization_panel.dart
+++ b/example/lib/src/features/home/views/widgets/customization_panel.dart
@@ -15,7 +15,7 @@ import 'package:example/src/core/views/widgets/toggle_tile.dart';
 import 'package:example/src/features/home/controllers/toast_detail.dart';
 import 'package:example/src/features/home/views/ui_states/animation_type.dart';
 import 'package:example/src/features/home/views/widgets/content.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_flutter/iconsax_flutter.dart';
 import 'package:responsive_framework/responsive_framework.dart';

--- a/example/lib/src/features/home/views/widgets/github_stars.dart
+++ b/example/lib/src/features/home/views/widgets/github_stars.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 import 'package:example/src/core/views/widgets/core.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_spinkit/flutter_spinkit.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';

--- a/example/lib/src/features/home/views/widgets/header.dart
+++ b/example/lib/src/features/home/views/widgets/header.dart
@@ -3,7 +3,7 @@ import 'package:example/src/core/usecase/responsive/responsive.dart';
 import 'package:example/src/features/home/views/ui_states/extra.dart';
 import 'package:example/src/features/home/views/widgets/github_stars.dart';
 import 'package:example/src/features/home/views/widgets/image.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:iconsax_flutter/iconsax_flutter.dart';

--- a/example/lib/src/features/home/views/widgets/image.dart
+++ b/example/lib/src/features/home/views/widgets/image.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const headerImage = AssetImage('assets/img/header.png');
 const logoImage = AssetImage('assets/img/logo-black.png');

--- a/example/lib/src/features/home/views/widgets/preview_panel.dart
+++ b/example/lib/src/features/home/views/widgets/preview_panel.dart
@@ -5,7 +5,7 @@ import 'package:example/src/features/home/controllers/toast_detail.dart';
 import 'package:example/src/features/home/views/ui_states/extra.dart';
 import 'package:example/src/features/home/views/ui_states/toast_code_formatter.dart';
 import 'package:example/src/features/home/views/ui_states/toast_detail_ui_state.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_highlight/themes/github.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:iconsax_flutter/iconsax_flutter.dart';

--- a/example/lib/src/theme/theme.dart
+++ b/example/lib/src/theme/theme.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:material_ui/material_ui.dart';
+//import 'package:google_fonts/google_fonts.dart';
 
 const _primary = Color(0xff3F5EFF);
 const _onPrimary = Color(0xffFFFFFF);
@@ -50,19 +50,26 @@ ThemeData _themeBuilder({bool useInterFont = true}) {
   );
 
   final TextTheme textTheme;
+  // TODO: Re-enable Google Fonts after google_fonts supports the standalone material_ui TextTheme type.
 
-  if (useInterFont) {
-    textTheme = GoogleFonts.interTextTheme().apply(
-      bodyColor: scheme.onSurface,
-      displayColor: scheme.onSurface,
-    );
-  } else {
-    textTheme = ThemeData.light(useMaterial3: true).textTheme.apply(
-          fontFamily: 'PlusJakartaDisplay',
-          bodyColor: scheme.onSurface,
-          displayColor: scheme.onSurface,
-        );
-  }
+  // if (useInterFont) {
+  //   textTheme = GoogleFonts.interTextTheme().apply(
+  //     bodyColor: scheme.onSurface,
+  //     displayColor: scheme.onSurface,
+  //   );
+  // } else {
+  //   textTheme = ThemeData.light(useMaterial3: true).textTheme.apply(
+  //         fontFamily: 'PlusJakartaDisplay',
+  //         bodyColor: scheme.onSurface,
+  //         displayColor: scheme.onSurface,
+  //       );
+  // }
+
+  textTheme = ThemeData.light(useMaterial3: true).textTheme.apply(
+    fontFamily: 'PlusJakartaDisplay',
+    bodyColor: scheme.onSurface,
+    displayColor: scheme.onSurface,
+  );
 
   return ThemeData(
     useMaterial3: true,

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     path: ../
   dart_style: ^3.0.1
   flutter_svg: ^2.0.6
-  font_awesome_flutter: ^10.4.0
+  font_awesome_flutter: ^11.0.0
   flutter_sticky_header: ^0.8.0
   highlight: ^0.7.0
   flutter_highlight: ^0.7.0
@@ -26,7 +26,7 @@ dependencies:
   freezed_annotation: ^3.0.0
   iconsax_flutter: ^1.0.0
   url_launcher: ^6.1.12
-  google_fonts: ^6.2.1
+  google_fonts: ^8.2.1
   flutter_staggered_grid_view: ^0.7.0
   flutter_spinkit: ^5.2.0
   http: ^1.1.0
@@ -37,6 +37,7 @@ dependencies:
   path: ^1.9.0
   sqlite3_flutter_libs: ^0.5.0
 
+  material_ui: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/lib/src/built_in/built_in_builder.dart
+++ b/lib/src/built_in/built_in_builder.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/widget/common/on_hover_builder.dart';
 import 'package:toastification/toastification.dart';
 

--- a/lib/src/built_in/layout/standard/style/factory.dart
+++ b/lib/src/built_in/layout/standard/style/factory.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 class StandardToastStyleFactory {

--- a/lib/src/built_in/layout/standard/style/implementation/filled_style.dart
+++ b/lib/src/built_in/layout/standard/style/implementation/filled_style.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/layout/standard/style/style.dart';
 import 'package:toastification/src/utils/color_utils.dart';
 

--- a/lib/src/built_in/layout/standard/style/implementation/flat_colored_style.dart
+++ b/lib/src/built_in/layout/standard/style/implementation/flat_colored_style.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/layout/standard/style/style.dart';
 import 'package:toastification/src/utils/color_utils.dart';
 

--- a/lib/src/built_in/layout/standard/style/implementation/flat_style.dart
+++ b/lib/src/built_in/layout/standard/style/implementation/flat_style.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/layout/standard/style/style.dart';
 import 'package:toastification/src/utils/color_utils.dart';
 

--- a/lib/src/built_in/layout/standard/style/implementation/minimal_style.dart
+++ b/lib/src/built_in/layout/standard/style/implementation/minimal_style.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/layout/standard/style/style.dart';
 import 'package:toastification/src/utils/color_utils.dart';
 

--- a/lib/src/built_in/layout/standard/style/implementation/simple_style.dart
+++ b/lib/src/built_in/layout/standard/style/implementation/simple_style.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/layout/standard/style/style.dart';
 import 'package:toastification/src/utils/color_utils.dart';
 

--- a/lib/src/built_in/layout/standard/style/style.dart
+++ b/lib/src/built_in/layout/standard/style/style.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 /// enum to define the style of the built-in toastification

--- a/lib/src/built_in/layout/standard/toast/base_standard.dart
+++ b/lib/src/built_in/layout/standard/toast/base_standard.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 // TODO: maybe we can use adapter pattern here

--- a/lib/src/built_in/layout/standard/toast/default/default_standard_toast.dart
+++ b/lib/src/built_in/layout/standard/toast/default/default_standard_toast.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/layout/standard/toast/base_standard.dart';
 import 'package:toastification/src/built_in/theme/toastification_theme_data.dart';
 import 'package:toastification/src/built_in/widget/common/close_button.dart';

--- a/lib/src/built_in/layout/standard/toast/minimal/minimal_standard_toast.dart
+++ b/lib/src/built_in/layout/standard/toast/minimal/minimal_standard_toast.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/layout/standard/toast/base_standard.dart';
 import 'package:toastification/src/utils/toast_theme_utils.dart';
 import 'package:toastification/src/built_in/theme/toastification_theme_data.dart';

--- a/lib/src/built_in/layout/standard/toast/simple/simple_standard_toast.dart
+++ b/lib/src/built_in/layout/standard/toast/simple/simple_standard_toast.dart
@@ -1,5 +1,5 @@
 import 'dart:ui';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/widget/common/close_button.dart';
 import 'package:toastification/src/utils/toast_theme_utils.dart';
 import 'package:toastification/toastification.dart';

--- a/lib/src/built_in/theme/toastification_theme.dart
+++ b/lib/src/built_in/theme/toastification_theme.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/theme/toastification_theme_data.dart';
 
 /// An inherited widget that defines the configuration for

--- a/lib/src/built_in/theme/toastification_theme_data.dart
+++ b/lib/src/built_in/theme/toastification_theme_data.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 /// A class that defines the theming data for Toastification widgets.

--- a/lib/src/built_in/toastification_type.dart
+++ b/lib/src/built_in/toastification_type.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/built_in/theme/toastification_icons.dart';
 import 'package:toastification/src/utils/constants_values.dart';
 

--- a/lib/src/built_in/widget/common/close_button.dart
+++ b/lib/src/built_in/widget/common/close_button.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/utils/toast_theme_utils.dart';
 
 /// Signature for a function that builds a custom close button widget.
@@ -107,7 +107,7 @@ class ToastCloseButtonHolder extends StatelessWidget {
               child: SizeTransition(
                 sizeFactor: animation,
                 axis: Axis.horizontal,
-                axisAlignment: 1,
+                alignment: Alignment.centerRight,
                 child: child,
               ),
             );

--- a/lib/src/built_in/widget/common/on_hover_builder.dart
+++ b/lib/src/built_in/widget/common/on_hover_builder.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 typedef OnHoverBuilder = Widget Function(BuildContext context, bool showWidget);
 

--- a/lib/src/built_in/widget/common/toast_content.dart
+++ b/lib/src/built_in/widget/common/toast_content.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/utils/toast_theme_utils.dart';
 import 'package:toastification/toastification.dart';
 

--- a/lib/src/core/toastification.dart
+++ b/lib/src/core/toastification.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:toastification/src/built_in/built_in_builder.dart';
 import 'package:toastification/src/core/toastification_manager.dart';

--- a/lib/src/core/toastification_callbacks.dart
+++ b/lib/src/core/toastification_callbacks.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 /// A set of callbacks that you can provide to a [Toastification] widget.

--- a/lib/src/core/toastification_config.dart
+++ b/lib/src/core/toastification_config.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 @visibleForTesting

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:toastification/src/core/widget/toast_builder.dart';

--- a/lib/src/core/toastification_overlay_state.dart
+++ b/lib/src/core/toastification_overlay_state.dart
@@ -1,6 +1,6 @@
 // Originally copied from https://github.com/boyan01/overlay_support/blob/master/lib/src/overlay_state_finder.dart
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/core/toastification_config.dart';
 import 'package:toastification/src/core/widget/toastification_config_provider.dart';
 

--- a/lib/src/core/widget/toast_animation.dart
+++ b/lib/src/core/widget/toast_animation.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/src/utils/common_utils.dart';
 import 'package:toastification/toastification.dart';
 

--- a/lib/src/core/widget/toast_builder.dart
+++ b/lib/src/core/widget/toast_builder.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 import 'dart:math' as math;
 

--- a/lib/src/utils/color_utils.dart
+++ b/lib/src/utils/color_utils.dart
@@ -1,5 +1,5 @@
 import 'package:collection/collection.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 /// Utility class for color manipulation and conversion operations.
 class ColorUtils {

--- a/lib/src/utils/constants_values.dart
+++ b/lib/src/utils/constants_values.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 
 const infoColor = Color(0xFF47AFFF);
 

--- a/lib/src/utils/toast_theme_utils.dart
+++ b/lib/src/utils/toast_theme_utils.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:toastification/toastification.dart';
 
 extension ContextExt on BuildContext {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   pausable_timer: ^3.1.0+3
   collection: ^1.18.0
 
+  material_ui: any
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/src/built_in/built_in_container_test.dart
+++ b/test/src/built_in/built_in_container_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/src/built_in/widget/built_in_container.dart';
 import 'package:toastification/toastification.dart';

--- a/test/src/built_in/layout/standard/style/style_test.dart
+++ b/test/src/built_in/layout/standard/style/style_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/src/built_in/layout/standard/toast/factory_test.dart
+++ b/test/src/built_in/layout/standard/toast/factory_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/src/built_in/theme/toastification_theme_data_test.dart
+++ b/test/src/built_in/theme/toastification_theme_data_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/src/built_in/theme/toastification_theme_test.dart
+++ b/test/src/built_in/theme/toastification_theme_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/src/core/toastification_callbacks_test.dart
+++ b/test/src/core/toastification_callbacks_test.dart
@@ -1,6 +1,6 @@
 // ignore_for_file: prefer_function_declarations_over_variables
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/src/core/toastification_config_test.dart
+++ b/test/src/core/toastification_config_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/src/core/toastification_manager_test.dart
+++ b/test/src/core/toastification_manager_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/src/core/toastification_manager.dart';
 import 'package:toastification/toastification.dart';

--- a/test/src/core/toastification_overlay_state_test.dart
+++ b/test/src/core/toastification_overlay_state_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/src/core/toastification_overlay_state.dart';
 import 'package:toastification/toastification.dart';

--- a/test/src/core/toastification_test.dart
+++ b/test/src/core/toastification_test.dart
@@ -1,6 +1,6 @@
 import 'dart:developer';
 
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/src/built_in/built_in_builder.dart';
 import 'package:toastification/toastification.dart';

--- a/test/src/core/widget/toast_animation_test.dart
+++ b/test/src/core/widget/toast_animation_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/toastification.dart';
 

--- a/test/toastification_type_test.dart
+++ b/test/toastification_type_test.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:material_ui/material_ui.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:toastification/src/built_in/theme/toastification_icons.dart';
 import 'package:toastification/src/built_in/toastification_type.dart';


### PR DESCRIPTION
### Summary

This PR updates the package for **Flutter 3.47.1** and migrates the existing Material and Cupertino UI code to the new standalone `material_ui` and `cupertino_ui` packages.

### Changes

- Updated Flutter compatibility to **3.47.1**
- Migrated package:flutter/material.dart usage to package:material_ui/material_ui.dart
- Migrated package:flutter/cupertino.dart usage to package:cupertino_ui/cupertino_ui.dart
- Updated affected imports to work with the standalone UI packages

### Notes

This is a compatibility a migration update. No changes have been made to the package's existing behavior.