### PR TITLE
fix: tear the overlay down after the exit animation, not on a timer racing it (double dispose on web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- fix: tear the overlay down once the exit animation has completed, not on a timer that could land in the very frame completing it — on the web that disposed the `AnimatedList` item controller twice (`Null check operator used on a null value` in `AnimationController.dispose`).
+
 # 3.2.0
 
 - feature: add new parameter for on hover mouse cursor by @payam-zahedi

--- a/lib/src/core/toastification_manager.dart
+++ b/lib/src/core/toastification_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/scheduler.dart';
@@ -131,8 +133,9 @@ class ToastificationManager {
 
         delay = animationDuration + delay;
 
-        listGlobalKey.currentState?.removeItem(
+        _removeItemWithExitWatch(
           index,
+          removedItem,
           (BuildContext context, Animation<double> animation) {
             return ToastHolderWidget(
               item: removedItem,
@@ -147,11 +150,13 @@ class ToastificationManager {
         /// if the [showRemoveAnimation] is false, we will remove the notification
         /// without showing the remove animation.
       } else {
-        listGlobalKey.currentState?.removeItem(
+        _removeItemWithExitWatch(
           index,
+          removedItem,
           (BuildContext context, Animation<double> animation) {
             return const SizedBox.shrink();
           },
+          duration: _defaultRemoveDuration,
         );
       }
 
@@ -163,19 +168,94 @@ class ToastificationManager {
       /// we will remove the [_overlayEntry] if there are no notifications
       /// We need to check if the _notifications list is empty twice.
       /// To make sure after the delay, there are no new notifications added.
+      ///
+      /// This timer is only a safety net for exit animations that were never
+      /// observed (see [_removeItemWithExitWatch]): while the animation is
+      /// still running, its status listener owns the teardown. Tearing the
+      /// overlay down from here would race the [AnimatedList]'s own
+      /// bookkeeping and dispose the animation controller twice.
       if (notifications.isEmpty) {
         Future.delayed(
           delay,
           () {
-            if (notifications.isEmpty) {
-              overlayEntry?.remove();
-              overlayEntry?.dispose();
-              overlayEntry = null;
+            final exit = exitAnimations[removedItem.id];
+            if (exit is AnimationController && exit.isAnimating) {
+              return;
             }
+            exitAnimations.remove(removedItem.id);
+            _removeOverlayIfIdle();
           },
         );
       }
     }
+  }
+
+  /// [AnimatedList.removeItem]'s own default duration, replicated because the
+  /// framework keeps it private.
+  static const Duration _defaultRemoveDuration = Duration(milliseconds: 300);
+
+  /// Exit animations currently running, keyed by [ToastificationItem.id].
+  ///
+  /// The overlay may only be torn down once the framework has finished its
+  /// own bookkeeping for every one of them, see [_removeItemWithExitWatch].
+  @visibleForTesting
+  final Map<String, Animation<double>> exitAnimations = {};
+
+  /// Starts the exit animation of [item] on the [AnimatedList] and drives the
+  /// overlay teardown from the animation itself.
+  ///
+  /// `AnimatedListState.removeItem` disposes the animation controller in a
+  /// `.then` MICROTASK once the exit animation completes, and the list's
+  /// `State.dispose` disposes every controller still in flight too. If the
+  /// overlay entry is removed in the very frame that completes the animation,
+  /// that microtask runs after the dispose — on the web the engine does not
+  /// flush microtasks between `onBeginFrame` and `onDrawFrame` — and the
+  /// controller is disposed twice: `Null check operator used on a null value`
+  /// in `AnimationController.dispose`. A timer set to the animation duration
+  /// lands in exactly that frame as soon as frames stall (background tab,
+  /// rendering hiccup).
+  ///
+  /// So the teardown waits for [AnimationStatus.dismissed] and is queued as a
+  /// microtask from the status listener, i.e. AFTER the framework's own
+  /// `.then` for that very tick. By the time it runs, the controller has left
+  /// the list's bookkeeping and the dispose has nothing left to free twice.
+  void _removeItemWithExitWatch(
+    int index,
+    ToastificationItem item,
+    AnimatedRemovedItemBuilder builder, {
+    required Duration duration,
+  }) {
+    void watch(Animation<double> animation) {
+      // The builder runs on every frame of the exit; watch only once.
+      if (exitAnimations.containsKey(item.id)) return;
+      exitAnimations[item.id] = animation;
+
+      void onStatus(AnimationStatus status) {
+        if (status != AnimationStatus.dismissed) return;
+        animation.removeStatusListener(onStatus);
+        exitAnimations.remove(item.id);
+        scheduleMicrotask(_removeOverlayIfIdle);
+      }
+
+      animation.addStatusListener(onStatus);
+    }
+
+    listGlobalKey.currentState?.removeItem(
+      index,
+      (BuildContext context, Animation<double> animation) {
+        watch(animation);
+        return builder(context, animation);
+      },
+      duration: duration,
+    );
+  }
+
+  /// Removes the [overlayEntry] once no toast is shown nor still exiting.
+  void _removeOverlayIfIdle() {
+    if (notifications.isNotEmpty || exitAnimations.isNotEmpty) return;
+    overlayEntry?.remove();
+    overlayEntry?.dispose();
+    overlayEntry = null;
   }
 
   /// This function dismisses all the notifications in the [notifications] list.

--- a/test/src/core/toastification_manager_test.dart
+++ b/test/src/core/toastification_manager_test.dart
@@ -410,9 +410,9 @@ void main() {
       expect(manager.overlayEntry, isNotNull);
 
       manager.dismiss(item);
-      // Wait for animation and removal delay
-      await tester.pump(const Duration(milliseconds: 100)); // animation
-      await tester.pump(manager.removeOverlayDelay); // removal delay
+      // The overlay is torn down once the exit animation has actually
+      // completed, not on a timer: settle it.
+      await tester.pumpAndSettle();
 
       expect(manager.overlayEntry, isNull);
     });
@@ -576,9 +576,9 @@ void main() {
 
       manager.dismissAll(delayForAnimation: false);
 
-      // Wait for animation and removal delay
-      await tester.pump(const Duration(milliseconds: 100)); // animation
-      await tester.pump(manager.removeOverlayDelay); // removal delay
+      // The overlay is torn down once the exit animation has actually
+      // completed, not on a timer: settle it.
+      await tester.pumpAndSettle();
 
       expect(manager.overlayEntry, isNull);
     });

--- a/test/src/core/toastification_manager_web_frame_test.dart
+++ b/test/src/core/toastification_manager_web_frame_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:toastification/src/core/toastification_manager.dart';
+import 'package:toastification/toastification.dart';
+
+/// Regression: `dismiss` used to remove the overlay entry from a timer set to
+/// `animationDuration + removeOverlayDelay`. `AnimatedListState.removeItem`
+/// disposes the item's animation controller in a `.then` MICROTASK once the
+/// exit animation completes, and the list's `State.dispose` disposes every
+/// in-flight controller too. When the tick completing the animation and the
+/// build removing the overlay land in the same frame — the rule as soon as
+/// frames stall (background tab, rendering hiccup) — the microtask runs after
+/// the dispose on the web, because the web engine does not flush microtasks
+/// between `onBeginFrame` and `onDrawFrame` (see the comment above
+/// `invokeOnDrawFrame` in `web_ui/lib/src/engine/frame_service.dart`), and
+/// the controller is disposed twice.
+///
+/// The test binding flushes microtasks between the two phases like the mobile
+/// engine does, so the faulty frame is driven by hand here: `handleBeginFrame`
+/// then `handleDrawFrame` in one task, microtasks flushed afterwards.
+void main() {
+  late ToastificationManager manager;
+  late OverlayState overlayState;
+
+  setUp(() {
+    manager = ToastificationManager(
+      alignment: Alignment.topRight,
+      config: const ToastificationConfig(),
+    );
+  });
+
+  Future<void> createOverlay(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              overlayState = Overlay.of(context);
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets(
+      'dismiss: exit animation completing in the frame that removes the overlay '
+      'must not dispose the item controller twice (web frame order)',
+      (WidgetTester tester) async {
+    await createOverlay(tester);
+    const animationDuration = Duration(milliseconds: 100);
+
+    final item = manager.showCustom(
+      overlayState: overlayState,
+      scheduler: tester.binding,
+      builder: (context, item) => const Text('Test Toast'),
+      animationBuilder: null,
+      animationDuration: animationDuration,
+      callbacks: const ToastificationCallbacks(),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Test Toast'), findsOneWidget);
+
+    manager.dismiss(item);
+    // First tick of the exit animation: fixes its origin.
+    await tester.pump();
+    expect(find.text('Test Toast'), findsOneWidget);
+
+    // Frames stall while timers keep running: the old teardown timer fires
+    // and the exit animation is past its duration without a single tick.
+    await tester.binding
+        .delayed(animationDuration + manager.removeOverlayDelay);
+
+    // One web frame: begin + draw in the same task, THEN the microtasks.
+    final binding = tester.binding;
+    binding.handleBeginFrame(
+      Duration(microseconds: binding.clock.now().microsecondsSinceEpoch),
+    );
+    binding.handleDrawFrame();
+    // Flushes the microtasks: the framework's `.then` runs here. Before the
+    // fix: "AnimationController.dispose() called more than once".
+    await tester.pump();
+
+    await tester.pump();
+    expect(find.text('Test Toast'), findsNothing);
+    expect(manager.overlayEntry, isNull);
+    expect(manager.exitAnimations, isEmpty);
+  });
+
+  testWidgets(
+      'dismissAll: the overlay waits for the LAST exit animation, not the first',
+      (WidgetTester tester) async {
+    await createOverlay(tester);
+
+    for (var i = 0; i < 2; i++) {
+      manager.showCustom(
+        overlayState: overlayState,
+        scheduler: tester.binding,
+        builder: (context, item) => Text('Toast $i'),
+        animationBuilder: null,
+        animationDuration: const Duration(milliseconds: 100),
+        callbacks: const ToastificationCallbacks(),
+      );
+    }
+    await tester.pumpAndSettle();
+
+    // `dismissAll` dismisses toast 1 now and toast 0 150 ms later, so the
+    // first exit completes while the second is still in flight. An exit
+    // animation is done once STRICTLY past its duration, counted from its
+    // first tick.
+    manager.dismissAll();
+    await tester.pump(const Duration(milliseconds: 100)); // t=100: first tick of toast 1
+    await tester.pump(const Duration(milliseconds: 100)); // t=200: toast 0 dismissed at 150, its first tick
+    await tester.pump(const Duration(milliseconds: 1)); // t=201: toast 1 done, toast 0 still exiting
+    expect(manager.overlayEntry, isNotNull);
+    expect(manager.exitAnimations.length, 1);
+
+    await tester.pump(const Duration(milliseconds: 100)); // t=301: toast 0 done
+    expect(manager.overlayEntry, isNull);
+    expect(manager.exitAnimations, isEmpty);
+  });
+}


### PR DESCRIPTION
## The bug

On Flutter web, dismissing the last toast crashes intermittently with `Null check operator used on a null value` thrown by `AnimationController.dispose` (`_ticker!`), called from `_SliverAnimatedMultiBoxAdaptorState.removeItem.<closure>` out of the microtask loop. In debug it is the assertion `AnimationController.dispose() called more than once.`

Seen in production on a Flutter 3.41 web app: 131 events for 71 distinct users over 7 days, on pages where toasts auto-close. It never shows up on mobile.

## Why

`AnimatedListState.removeItem` disposes the item's controller in a `.then` — a **microtask** — once the exit animation completes, and the sliver list's `State.dispose` disposes every in-flight controller as well, without clearing its `_outgoingItems`.

`ToastificationManager.dismiss` starts the exit animation (duration D) **and** a timer set to `D + removeOverlayDelay` that removes the overlay entry when no toast is left. As soon as frames stall between the two — a background tab (rAF paused, timers still firing) or a rendering hiccup — the tick completing the animation and the build removing the overlay land in the **same frame**:

1. the tick completes the `TickerFuture` → the framework's `.then` is queued as a microtask;
2. the build unmounts the `AnimatedList` → its `dispose` disposes the controller;
3. the microtask runs, still finds the entry in `_outgoingItems`, and disposes the controller a second time → `_ticker!` on null.

On mobile the engine flushes microtasks between `onBeginFrame` and `onDrawFrame`, so step 3 happens before step 2. On the web it does not — see the comment above `invokeOnDrawFrame` in `engine/src/flutter/lib/web_ui/lib/src/engine/frame_service.dart`.

## The fix

The overlay teardown is now driven by the exit animation itself: the `removedItemBuilder` attaches (once) a status listener to the animation, and on `AnimationStatus.dismissed` the teardown is queued with `scheduleMicrotask`, i.e. **after** the framework's own `.then` for that very tick. By the time it runs, the controller has left the list's bookkeeping and the dispose has nothing left to free twice. This holds on both frame orders (mobile flushes both microtasks before `drawFrame`; the web runs them after it, and the overlay goes away on the next frame).

The `D + removeOverlayDelay` timer remains only as a safety net for exit animations that were never observed (e.g. the list was never built). When several toasts exit at once (`dismissAll`), the overlay now waits for the last animation instead of cutting the others short — `exitAnimations` tracks them.

## Related

The framework-side root cause is reported as flutter/flutter#192533 (`_SliverAnimatedMultiBoxAdaptorState.dispose` does not clear its lists and the `removeItem` / `insertItem` completion callbacks do not check `mounted`). Until that lands, any teardown scheduled against the animation's duration can hit this on the web; this change makes the package safe regardless.

## Tests

- `test/src/core/toastification_manager_web_frame_test.dart` drives one frame the way the web engine does (`handleBeginFrame` + `handleDrawFrame` in one task, microtasks flushed afterwards — the test binding flushes them between the two phases like mobile, so a plain `pump` cannot reproduce). It fails on `main` with `AnimationController.dispose() called more than once` and passes with this change. A second test covers the "wait for the last exit" behaviour.
- Two existing manager tests asserted the overlay was gone after `animationDuration + removeOverlayDelay`; that timing actually cut the exit animation short in the test binding (the animation's origin is its first tick, and it completes strictly past its duration). They now `pumpAndSettle` and assert the same thing.
- Full suite: 130 tests passing, `flutter analyze` clean, Flutter 3.41.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
